### PR TITLE
Swift 4 breaks excepting reserved keywords

### DIFF
--- a/Sources/BluetoothHostController.swift
+++ b/Sources/BluetoothHostController.swift
@@ -13,10 +13,14 @@ public protocol BluetoothHostControllerInterface {
     
     /// All controllers on the host.
     static var controllers: [Self] { get }
-    
+
+#if swift(>=3.2)
     /// The default controller on the host.
+    static var defaultController: Self? { get }
+#else
     static var `default`: Self? { get }
-    
+#endif
+
     /// The Bluetooth Address of the controller.
     var address: Address { get }
     


### PR DESCRIPTION
I don't believe it's possible to have an `@available` without also having the old parameter visible.  So, I'm not sure it's possible for us to have the nice fixit