### PR TITLE
Fixed `GATTSystemID` and added `UInt40 and `UInt24`

### DIFF
--- a/Sources/GATTSystemID.swift
+++ b/Sources/GATTSystemID.swift
@@ -125,6 +125,6 @@ extension GATTSystemID: CustomStringConvertible {
     
     public var description: String {
         
-        return rawValue.bigEndian.toHexadecimal()
+        return rawValue.toHexadecimal()
     }
 }

--- a/Sources/GATTSystemID.swift
+++ b/Sources/GATTSystemID.swift
@@ -11,15 +11,9 @@ import Foundation
 /**
  System ID
  
- The SYSTEM ID characteristic consists of a structure with two fields. The first field are the LSOs and the second field contains the MSOs. This is a 64-bit structure which consists of a 40-bit manufacturer-defined identifier concatenated with a 24 bit unique Organizationally Unique Identifier (OUI). The OUI is issued by the IEEE Registration Authority (http://standards.ieee.org/regauth/index.html) and is required to be used in accordance with IEEE Standard 802-2001.6 while the least significant 40 bits are manufacturer defined.
- 
- If System ID generated based on a Bluetooth Device Address, it is required to be done as follows. System ID and the Bluetooth Device Address have a very similar structure: a Bluetooth Device Address is 48 bits in length and consists of a 24 bit Company Assigned Identifier (manufacturer defined identifier) concatenated with a 24 bit Company Identifier (OUI). In order to encapsulate a Bluetooth Device Address as System ID, the Company Identifier is concatenated with 0xFFFE followed by the Company Assigned Identifier of the Bluetooth Address. For more guidelines related to EUI-64, refer to http://standards.ieee.org/develop/regauth/tut/eui64.pdf.
+ The SYSTEM ID characteristic consists of a structure with two fields. The first field are the LSOs and the second field contains the MSOs. This is a 64-bit structure which consists of a 40-bit manufacturer-defined identifier concatenated with a 24 bit unique Organizationally Unique Identifier (OUI). The OUI is issued by the [IEEE Registration Authority](http://standards.ieee.org/regauth/index.html) and is required to be used in accordance with IEEE Standard 802-2001.6 while the least significant 40 bits are manufacturer defined.
  
  [System ID](https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.characteristic.system_id.xml)
- 
- - Note:
- 
-    The fields in the above table are in the order of LSO to MSO. Where LSO = Least Significant Octet and MSO = Most Significant Octet.
  */
 public struct GATTSystemID: GATTCharacteristic, RawRepresentable {
     
@@ -66,11 +60,29 @@ public struct GATTSystemID: GATTCharacteristic, RawRepresentable {
         return UInt24(bigEndian: UInt24(bytes: (bytes.0, bytes.1, bytes.2)))
     }
     
-    /*
-    public init(address: Bluetooth.Address, organizationallyUniqueIdentifier: UInt24) {
+    /// Initialize a System ID based on a Bluetooth Device Address.
+    public init(address: Bluetooth.Address) {
         
+        /**
+         If System ID generated based on a Bluetooth Device Address, it is required to be done as follows. System ID and the Bluetooth Device Address have a very similar structure: a Bluetooth Device Address is 48 bits in length and consists of a 24 bit Company Assigned Identifier (manufacturer defined identifier) concatenated with a 24 bit Company Identifier (OUI). In order to encapsulate a Bluetooth Device Address as System ID, the Company Identifier is concatenated with 0xFFFE followed by the Company Assigned Identifier of the Bluetooth Address.
+         
+         Example:
+         If the system ID is based of a Bluetooth Device Address with a Company Identifier (OUI) is 0x123456 and the Company Assigned Identifier is 0x9ABCDE, then the System Identifier is required to be 0x123456FFFE9ABCDE
+         */
         
-    }*/
+        let manufacturerIdentifierPrefix = UInt16(0xFFFE).bigEndian.bytes
+        
+        let addressBytes = address.bigEndian.bytes
+        
+        self.rawValue = UInt64(bigEndian: UInt64(bytes: (addressBytes.0,
+                                                         addressBytes.1,
+                                                         addressBytes.2,
+                                                         manufacturerIdentifierPrefix.0,
+                                                         manufacturerIdentifierPrefix.1,
+                                                         addressBytes.3,
+                                                         addressBytes.4,
+                                                         addressBytes.5)))
+    }
     
     public init?(data: Data) {
         

--- a/Sources/UInt24.swift
+++ b/Sources/UInt24.swift
@@ -1,0 +1,139 @@
+//
+//  UInt24.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 6/28/18.
+//  Copyright © 2018 PureSwift. All rights reserved.
+//
+
+import Foundation
+
+/// A 24 bit number stored according to host endianness.
+public struct UInt24: ByteValue {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { return 24 }
+    
+    public var bytes: ByteValue
+    
+    public init(bytes: ByteValue = (0, 0, 0)) {
+        
+        self.bytes = bytes
+    }
+}
+
+public extension UInt24 {
+    
+    /// The minimum representable value in this type.
+    public static var min: UInt24 { return UInt24(bytes: (.min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    public static var max: UInt24 { return UInt24(bytes: (.max, .max, .max)) }
+    
+    /// The value with all bits set to zero.
+    public static var zero: UInt24 { return .min }
+}
+
+// MARK: - Equatable
+
+extension UInt24: Equatable {
+    
+    public static func == (lhs: UInt24, rhs: UInt24) -> Bool {
+        
+        return lhs.bytes.0 == rhs.bytes.0 &&
+            lhs.bytes.1 == rhs.bytes.1 &&
+            lhs.bytes.2 == rhs.bytes.2
+    }
+}
+
+// MARK: - Hashable
+
+extension UInt24: Hashable {
+    
+    public var hashValue: Int {
+        
+        return UInt32(self).hashValue
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UInt24: CustomStringConvertible {
+    
+    public var description: String {
+        
+        let bytes = self.bigEndian.bytes
+        
+        return bytes.0.toHexadecimal()
+            + bytes.1.toHexadecimal()
+            + bytes.2.toHexadecimal()
+    }
+}
+
+// MARK: - Data Convertible
+
+public extension UInt24 {
+    
+    public static var length: Int { return 3 }
+    
+    public init?(data: Data) {
+        
+        guard data.count == UInt24.length else { return nil }
+        
+        self.init(bytes: (data[0], data[1], data[2]))
+    }
+    
+    public var data: Data {
+        
+        return Data(bytes: [bytes.0, bytes.1, bytes.2])
+    }
+}
+
+// MARK: - Byte Swap
+
+extension UInt24: ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    public var byteSwapped: UInt24 {
+        
+        return UInt24(bytes: (bytes.2, bytes.1, bytes.0))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UInt24: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt32) {
+        
+        self = UInt24(value)
+    }
+}
+
+// MARK: - Integer Conversion
+
+public extension UInt24 {
+    
+    /// Initialize from a unsigned 32-bit integer.
+    init(_ value: UInt32) {
+        
+        guard value <= UInt32(UInt24.max)
+            else { fatalError("Integer overflow") }
+        
+        let bytes = value.bigEndian.bytes
+        
+        self = UInt24(bigEndian: UInt24(bytes: (bytes.0, bytes.1, bytes.2)))
+    }
+}
+
+public extension UInt32 {
+    
+    /// Initialize from a unsigned 40-bit integer.
+    init(_ value: UInt24) {
+        
+        let bytes = value.bigEndian.bytes
+        
+        self = UInt32(bigEndian: UInt32(bytes: (0, bytes.0, bytes.1, bytes.2)))
+    }
+}

--- a/Sources/UInt24.swift
+++ b/Sources/UInt24.swift
@@ -41,9 +41,9 @@ extension UInt24: Equatable {
     
     public static func == (lhs: UInt24, rhs: UInt24) -> Bool {
         
-        return lhs.bytes.0 == rhs.bytes.0 &&
-            lhs.bytes.1 == rhs.bytes.1 &&
-            lhs.bytes.2 == rhs.bytes.2
+        return lhs.bytes.0 == rhs.bytes.0
+            && lhs.bytes.1 == rhs.bytes.1
+            && lhs.bytes.2 == rhs.bytes.2
     }
 }
 
@@ -66,8 +66,8 @@ extension UInt24: CustomStringConvertible {
         let bytes = self.bigEndian.bytes
         
         return bytes.0.toHexadecimal()
-            + bytes.1.toHexadecimal()
-            + bytes.2.toHexadecimal()
+             + bytes.1.toHexadecimal()
+             + bytes.2.toHexadecimal()
     }
 }
 
@@ -123,7 +123,7 @@ public extension UInt24 {
         
         let bytes = value.bigEndian.bytes
         
-        self = UInt24(bigEndian: UInt24(bytes: (bytes.0, bytes.1, bytes.2)))
+        self = UInt24(bigEndian: UInt24(bytes: (bytes.1, bytes.2, bytes.3)))
     }
 }
 

--- a/Sources/UInt24.swift
+++ b/Sources/UInt24.swift
@@ -129,7 +129,7 @@ public extension UInt24 {
 
 public extension UInt32 {
     
-    /// Initialize from a unsigned 40-bit integer.
+    /// Initialize from a unsigned 24-bit integer.
     init(_ value: UInt24) {
         
         let bytes = value.bigEndian.bytes

--- a/Sources/UInt40.swift
+++ b/Sources/UInt40.swift
@@ -127,7 +127,7 @@ public extension UInt40 {
         
         let bytes = value.bigEndian.bytes
         
-        self = UInt40(bigEndian: UInt40(bytes: (bytes.0, bytes.1, bytes.2, bytes.3, bytes.4)))
+        self = UInt40(bigEndian: UInt40(bytes: (bytes.3, bytes.4, bytes.5, bytes.6, bytes.7)))
     }
 }
 

--- a/Sources/UInt40.swift
+++ b/Sources/UInt40.swift
@@ -1,0 +1,143 @@
+//
+//  UInt40.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 6/28/18.
+//  Copyright © 2018 PureSwift. All rights reserved.
+//
+
+import Foundation
+
+/// A 40 bit number stored according to host endianness.
+public struct UInt40: ByteValue {
+    
+    public typealias ByteValue = (UInt8, UInt8, UInt8, UInt8, UInt8)
+    
+    public static var bitWidth: Int { return 40 }
+    
+    public var bytes: ByteValue
+    
+    public init(bytes: ByteValue = (0, 0, 0, 0, 0)) {
+        
+        self.bytes = bytes
+    }
+}
+
+public extension UInt40 {
+    
+    /// The minimum representable value in this type.
+    public static var min: UInt40 { return UInt40(bytes: (.min, .min, .min, .min, .min)) }
+    
+    /// The maximum representable value in this type.
+    public static var max: UInt40 { return UInt40(bytes: (.max, .max, .max, .max, .max)) }
+    
+    /// The value with all bits set to zero.
+    public static var zero: UInt40 { return .min }
+}
+
+// MARK: - Equatable
+
+extension UInt40: Equatable {
+    
+    public static func == (lhs: UInt40, rhs: UInt40) -> Bool {
+        
+        return lhs.bytes.0 == rhs.bytes.0 &&
+            lhs.bytes.1 == rhs.bytes.1 &&
+            lhs.bytes.2 == rhs.bytes.2 &&
+            lhs.bytes.3 == rhs.bytes.3 &&
+            lhs.bytes.4 == rhs.bytes.4
+    }
+}
+
+// MARK: - Hashable
+
+extension UInt40: Hashable {
+    
+    public var hashValue: Int {
+        
+        return UInt64(self).hashValue
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension UInt40: CustomStringConvertible {
+    
+    public var description: String {
+        
+        let bytes = self.bigEndian.bytes
+        
+        return bytes.0.toHexadecimal()
+            + bytes.1.toHexadecimal()
+            + bytes.2.toHexadecimal()
+            + bytes.3.toHexadecimal()
+            + bytes.4.toHexadecimal()
+    }
+}
+
+// MARK: - Data Convertible
+
+public extension UInt40 {
+    
+    public static var length: Int { return 5 }
+    
+    public init?(data: Data) {
+        
+        guard data.count == UInt40.length else { return nil }
+        
+        self.init(bytes: (data[0], data[1], data[2], data[3], data[4]))
+    }
+    
+    public var data: Data {
+        
+        return Data(bytes: [bytes.0, bytes.1, bytes.2, bytes.3, bytes.4])
+    }
+}
+
+// MARK: - Byte Swap
+
+extension UInt40: ByteSwap {
+    
+    /// A representation of this integer with the byte order swapped.
+    public var byteSwapped: UInt40 {
+        
+        return UInt40(bytes: (bytes.4, bytes.3, bytes.2, bytes.1, bytes.0))
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension UInt40: ExpressibleByIntegerLiteral {
+    
+    public init(integerLiteral value: UInt64) {
+        
+        self = UInt40(value)
+    }
+}
+
+// MARK: - Integer Conversion
+
+public extension UInt40 {
+    
+    /// Initialize from a unsigned 64-bit integer.
+    init(_ value: UInt64) {
+        
+        guard value <= UInt64(UInt40.max)
+            else { fatalError("Integer overflow") }
+        
+        let bytes = value.bigEndian.bytes
+        
+        self = UInt40(bigEndian: UInt40(bytes: (bytes.0, bytes.1, bytes.2, bytes.3, bytes.4)))
+    }
+}
+
+public extension UInt64 {
+    
+    /// Initialize from a unsigned 40-bit integer.
+    init(_ value: UInt40) {
+        
+        let bytes = value.bigEndian.bytes
+        
+        self = UInt64(bigEndian: UInt64(bytes: (0, 0, 0, bytes.0, bytes.1, bytes.2, bytes.3, bytes.4)))
+    }
+}

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -830,6 +830,8 @@ final class GATTCharacteristicTests: XCTestCase {
     
     func testSystemID() {
         
+        XCTAssertEqual(GATTSystemID.uuid, .systemId)
+        
         XCTAssertNil(GATTSystemID(data: Data([])))
         XCTAssertNil(GATTSystemID(data: Data([0xff])))
         XCTAssertNil(GATTSystemID(data: Data([0xff, 0xff])))
@@ -843,6 +845,7 @@ final class GATTCharacteristicTests: XCTestCase {
             
             let data = Data([0x12, 0x34, 0x56, 0xFF, 0xFE, 0x9A, 0xBC, 0xDE].reversed())
             
+            let address = Address(rawValue: "12:34:56:9A:BC:DE")!
             let manufacturerIdentifier: UInt40 = 0xFFFE9ABCDE
             let organizationallyUniqueIdentifier: UInt24 = 0x123456
             
@@ -852,7 +855,11 @@ final class GATTCharacteristicTests: XCTestCase {
             XCTAssertEqual(characteristic.manufacturerIdentifier, manufacturerIdentifier)
             XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, organizationallyUniqueIdentifier)
             XCTAssertEqual(characteristic.description, "123456FFFE9ABCDE")
+            XCTAssertEqual(characteristic.rawValue, 0x123456FFFE9ABCDE)
+            XCTAssertEqual(characteristic.hashValue, 0x123456FFFE9ABCDE)
+            XCTAssertEqual(characteristic.data, data)
             XCTAssertEqual(characteristic, GATTSystemID(data: data))
+            XCTAssertEqual(characteristic, GATTSystemID(address: address))
         }
         
         do {
@@ -864,6 +871,8 @@ final class GATTCharacteristicTests: XCTestCase {
             XCTAssertEqual(characteristic.manufacturerIdentifier, 0x0000000000000000)
             XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, 0x0000000000000000)
             XCTAssertEqual(characteristic.description, "0000000000000000")
+            XCTAssertEqual(characteristic.rawValue, 0x0000000000000000)
+            XCTAssertEqual(characteristic.hashValue, Int(bitPattern: UInt.min))
             XCTAssertEqual(GATTSystemID(data: data), GATTSystemID(data: data))
         }
         
@@ -876,6 +885,8 @@ final class GATTCharacteristicTests: XCTestCase {
             XCTAssertEqual(characteristic.manufacturerIdentifier, 1099511627775)
             XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, 16777215)
             XCTAssertEqual(characteristic.description, "FFFFFFFFFFFFFFFF")
+            XCTAssertEqual(characteristic.rawValue, 0xFFFFFFFFFFFFFFFF)
+            XCTAssertEqual(characteristic.hashValue, Int(bitPattern: UInt.max))
             XCTAssertEqual(GATTSystemID(data: data), GATTSystemID(data: data))
         }
     }

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -830,7 +830,28 @@ final class GATTCharacteristicTests: XCTestCase {
     
     func testSystemID() {
         
+        XCTAssertNil(GATTSystemID(data: Data([])))
+        XCTAssertNil(GATTSystemID(data: Data([0xff])))
         XCTAssertNil(GATTSystemID(data: Data([0xff, 0xff])))
+        XCTAssertNil(GATTSystemID(data: Data([0xff, 0xff, 0xff])))
+        
+        do {
+            
+            let data = Data()
+            
+            let manufacturerIdentifier: UInt40 = 0xFFFE9ABCDE
+            let organizationallyUniqueIdentifier: UInt24 = 0x123456
+            
+            guard let characteristic = GATTSystemID(data: data)
+                else { XCTFail("Could not decode from bytes"); return }
+            
+            // If the system ID is based of a Bluetooth Device Address with a Company Identifier (OUI)
+            // is 0x123456 and the Company Assigned Identifier is 0x9ABCDE,
+            // then the System Identifier is required to be 0x123456FFFE9ABCDE.
+            XCTAssertEqual(characteristic.manufacturerIdentifier, manufacturerIdentifier)
+            XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, organizationallyUniqueIdentifier)
+            XCTAssertEqual(characteristic, GATTSystemID(manufacturerIdentifier: manufacturerIdentifier, organizationallyUniqueIdentifier: organizationallyUniqueIdentifier))
+        }
         
         do {
             let data = Data([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -872,7 +872,7 @@ final class GATTCharacteristicTests: XCTestCase {
             XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, 0x0000000000000000)
             XCTAssertEqual(characteristic.description, "0000000000000000")
             XCTAssertEqual(characteristic.rawValue, 0x0000000000000000)
-            XCTAssertEqual(characteristic.hashValue, Int(bitPattern: UInt.min))
+            XCTAssertEqual(characteristic.hashValue, UInt64.min.hashValue)
             XCTAssertEqual(GATTSystemID(data: data), GATTSystemID(data: data))
         }
         
@@ -886,7 +886,7 @@ final class GATTCharacteristicTests: XCTestCase {
             XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, 16777215)
             XCTAssertEqual(characteristic.description, "FFFFFFFFFFFFFFFF")
             XCTAssertEqual(characteristic.rawValue, 0xFFFFFFFFFFFFFFFF)
-            XCTAssertEqual(characteristic.hashValue, Int(bitPattern: UInt.max))
+            XCTAssertEqual(characteristic.hashValue, UInt64.max.hashValue)
             XCTAssertEqual(GATTSystemID(data: data), GATTSystemID(data: data))
         }
     }

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -837,20 +837,34 @@ final class GATTCharacteristicTests: XCTestCase {
         
         do {
             
-            let data = Data()
+            /**
+             If the system ID is based of a Bluetooth Device Address with a Company Identifier (OUI) is 0x123456 and the Company Assigned Identifier is 0x9ABCDE, then the System Identifier is required to be 0x123456FFFE9ABCDE.
+             */
+            
+            let data = Data([0x56, 0x34, 0x12, 0xDE, 0xBC, 0x9A, 0xFE, 0xFF])
             
             let manufacturerIdentifier: UInt40 = 0xFFFE9ABCDE
             let organizationallyUniqueIdentifier: UInt24 = 0x123456
             
+            let characteristic = GATTSystemID(manufacturerIdentifier: manufacturerIdentifier,
+                                              organizationallyUniqueIdentifier: organizationallyUniqueIdentifier)
+                        
+            XCTAssertEqual(characteristic.manufacturerIdentifier, manufacturerIdentifier)
+            XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, organizationallyUniqueIdentifier)
+            XCTAssertEqual(characteristic.description, "123456FFFE9ABCDE")
+            XCTAssertEqual(characteristic, GATTSystemID(data: data))
+        }
+        
+        do {
+            let data = Data([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+            
             guard let characteristic = GATTSystemID(data: data)
                 else { XCTFail("Could not decode from bytes"); return }
             
-            // If the system ID is based of a Bluetooth Device Address with a Company Identifier (OUI)
-            // is 0x123456 and the Company Assigned Identifier is 0x9ABCDE,
-            // then the System Identifier is required to be 0x123456FFFE9ABCDE.
-            XCTAssertEqual(characteristic.manufacturerIdentifier, manufacturerIdentifier)
-            XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, organizationallyUniqueIdentifier)
-            XCTAssertEqual(characteristic, GATTSystemID(manufacturerIdentifier: manufacturerIdentifier, organizationallyUniqueIdentifier: organizationallyUniqueIdentifier))
+            XCTAssertEqual(characteristic.manufacturerIdentifier, 0x0000000000000000)
+            XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, 0x0000000000000000)
+            XCTAssertEqual(characteristic.description, "0000000000000000")
+            XCTAssertEqual(GATTSystemID(data: data), GATTSystemID(data: data))
         }
         
         do {
@@ -861,19 +875,8 @@ final class GATTCharacteristicTests: XCTestCase {
             
             XCTAssertEqual(characteristic.manufacturerIdentifier, 1099511627775)
             XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, 16777215)
+            XCTAssertEqual(characteristic.description, "FFFFFFFFFFFFFFFF")
             XCTAssertEqual(GATTSystemID(data: data), GATTSystemID(data: data))
-        }
-        
-        do {
-            let data = Data([0xf0, 0x00, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00])
-            
-            guard let characteristic = GATTSystemID(data: data)
-                else { XCTFail("Could not decode from bytes"); return }
-            
-            XCTAssertEqual(characteristic.manufacturerIdentifier, 240)
-            XCTAssertEqual(characteristic.organizationallyUniqueIdentifier, 40)
-            XCTAssertEqual(characteristic.description, "240 40")
-            XCTAssertEqual(characteristic.data, data)
         }
     }
 }

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -841,7 +841,7 @@ final class GATTCharacteristicTests: XCTestCase {
              If the system ID is based of a Bluetooth Device Address with a Company Identifier (OUI) is 0x123456 and the Company Assigned Identifier is 0x9ABCDE, then the System Identifier is required to be 0x123456FFFE9ABCDE.
              */
             
-            let data = Data([0x56, 0x34, 0x12, 0xDE, 0xBC, 0x9A, 0xFE, 0xFF])
+            let data = Data([0x12, 0x34, 0x56, 0xFF, 0xFE, 0x9A, 0xBC, 0xDE].reversed())
             
             let manufacturerIdentifier: UInt40 = 0xFFFE9ABCDE
             let organizationallyUniqueIdentifier: UInt24 = 0x123456

--- a/Tests/BluetoothTests/UInt24Tests.swift
+++ b/Tests/BluetoothTests/UInt24Tests.swift
@@ -1,0 +1,57 @@
+//
+//  UInt24Tests.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 6/28/18.
+//  Copyright © 2018 PureSwift. All rights reserved.
+//
+
+
+import XCTest
+import Foundation
+@testable import Bluetooth
+
+final class UInt24Tests: XCTestCase {
+    
+    static let allTests = [
+        ("testBitWidth", testBitWidth),
+        ("testEquatable", testEquatable),
+        ("testHashable", testHashable),
+        ("testExpressibleByIntegerLiteral", testExpressibleByIntegerLiteral)
+    ]
+    
+    func testBitWidth() {
+        
+        XCTAssertEqual(UInt24.bitWidth, MemoryLayout<UInt24.ByteValue>.size * 8)
+        XCTAssertEqual(UInt24.bitWidth, 24)
+    }
+    
+    func testEquatable() {
+        
+        XCTAssertEqual(UInt24.zero, 0)
+        XCTAssertEqual(UInt24.min, 0)
+        XCTAssertEqual(UInt24.max, 16777215)
+        XCTAssertEqual(UInt24.max, 0xFFFFFF)
+    }
+    
+    func testHashable() {
+        
+        XCTAssertEqual(UInt24.zero.hashValue, 0)
+        XCTAssertNotEqual(UInt24.max.hashValue, 0)
+    }
+    
+    func testExpressibleByIntegerLiteral() {
+        
+        let values: [(UInt24, String)] = [
+            (UInt24.zero, "000000"),
+            (0x000000, "000000"),
+            (0x000001, "000001"),
+            (0x000020, "000020"),
+            (0xABCDEF, "ABCDEF"),
+            (16777215, "FFFFFF"),
+            (0xFFFFFF, "FFFFFF")
+        ]
+        
+        values.forEach { XCTAssertEqual($0.0.description, $0.1) }
+    }
+}

--- a/Tests/BluetoothTests/UInt40Tests.swift
+++ b/Tests/BluetoothTests/UInt40Tests.swift
@@ -1,0 +1,55 @@
+//
+//  UInt40Tests.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 6/28/18.
+//  Copyright © 2018 PureSwift. All rights reserved.
+//
+
+import XCTest
+import Foundation
+@testable import Bluetooth
+
+final class UInt40Tests: XCTestCase {
+    
+    static let allTests = [
+        ("testBitWidth", testBitWidth),
+        ("testEquatable", testEquatable),
+        ("testHashable", testHashable),
+        ("testExpressibleByIntegerLiteral", testExpressibleByIntegerLiteral)
+    ]
+    
+    func testBitWidth() {
+        
+        XCTAssertEqual(UInt40.bitWidth, MemoryLayout<UInt40.ByteValue>.size * 8)
+        XCTAssertEqual(UInt40.bitWidth, 40)
+    }
+    
+    func testEquatable() {
+        
+        XCTAssertEqual(UInt40.zero, 0)
+        XCTAssertEqual(UInt40.min, 0)
+        XCTAssertEqual(UInt40.max, 1099511627775)
+        XCTAssertEqual(UInt40.max, 0xFFFFFFFFFF)
+    }
+    
+    func testHashable() {
+        
+        XCTAssertEqual(UInt40.zero.hashValue, 0)
+        XCTAssertNotEqual(UInt40.max.hashValue, 0)
+    }
+    
+    func testExpressibleByIntegerLiteral() {
+        
+        let values: [(UInt40, String)] = [
+            (UInt40.zero, "0000000000"),
+            (0x0000000000, "0000000000"),
+            (0x0000000001, "0000000001"),
+            (0x0000000020, "0000000020"),
+            (0xFFFE9ABCDE, "FFFE9ABCDE"),
+            (1099511627775, "FFFFFFFFFF")
+        ]
+        
+        values.forEach { XCTAssertEqual($0.0.description, $0.1) }
+    }
+}

--- a/Xcode/Bluetooth.xcodeproj/project.pbxproj
+++ b/Xcode/Bluetooth.xcodeproj/project.pbxproj
@@ -633,7 +633,6 @@
 		3588AC1D20CD05AC00F9FA8C /* GAPData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3531BBD920CD013700EBB028 /* GAPData.swift */; };
 		3588AC1E20CD05AD00F9FA8C /* GAPData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3531BBD920CD013700EBB028 /* GAPData.swift */; };
 		35B7CADD20C5E72100F797AE /* GATTProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B7CADC20C5E72100F797AE /* GATTProfile.swift */; };
-		4B5C022920D834E10079C645 /* GATTBodyCompositionMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5C022820D834E10079C645 /* GATTBodyCompositionMeasurement.swift */; };
 		35CA73CF20D9674D000E49F7 /* GATTBootMouseInputReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CA73CE20D9674D000E49F7 /* GATTBootMouseInputReport.swift */; };
 		35CA73D020D9674D000E49F7 /* GATTBootMouseInputReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CA73CE20D9674D000E49F7 /* GATTBootMouseInputReport.swift */; };
 		35CA73D120D9674D000E49F7 /* GATTBootMouseInputReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CA73CE20D9674D000E49F7 /* GATTBootMouseInputReport.swift */; };
@@ -663,6 +662,7 @@
 		35F5BB6D20E4088400AC5FF1 /* GATTHardwareRevisionString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F5BB6B20E4088400AC5FF1 /* GATTHardwareRevisionString.swift */; };
 		35F5BB6E20E4088400AC5FF1 /* GATTHardwareRevisionString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F5BB6B20E4088400AC5FF1 /* GATTHardwareRevisionString.swift */; };
 		35F5BB6F20E4088400AC5FF1 /* GATTHardwareRevisionString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F5BB6B20E4088400AC5FF1 /* GATTHardwareRevisionString.swift */; };
+		4B5C022920D834E10079C645 /* GATTBodyCompositionMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5C022820D834E10079C645 /* GATTBodyCompositionMeasurement.swift */; };
 		511A657B2075B61400538116 /* LowEnergyResolvingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511A657A2075B61400538116 /* LowEnergyResolvingList.swift */; };
 		512F4B47208A562E00576F34 /* UInt256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512F4B46208A562E00576F34 /* UInt256.swift */; };
 		512F4B48208A564400576F34 /* UInt256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512F4B46208A562E00576F34 /* UInt256.swift */; };
@@ -677,6 +677,14 @@
 		6E0245DB20683DBD007FB15E /* HCIPacketHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0245D720683DBD007FB15E /* HCIPacketHeader.swift */; };
 		6E04273A208008A200AD3C75 /* BluetoothUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E65DF802075135E005BD2A0 /* BluetoothUUIDTests.swift */; };
 		6E04273D20800B0700AD3C75 /* DefinedUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1A0C4C208006370095C29E /* DefinedUUIDTests.swift */; };
+		6E069B6E20E4FEDC00669B76 /* UInt24.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B6D20E4FEDC00669B76 /* UInt24.swift */; };
+		6E069B6F20E4FEDC00669B76 /* UInt24.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B6D20E4FEDC00669B76 /* UInt24.swift */; };
+		6E069B7020E4FEDC00669B76 /* UInt24.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B6D20E4FEDC00669B76 /* UInt24.swift */; };
+		6E069B7120E4FEDC00669B76 /* UInt24.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B6D20E4FEDC00669B76 /* UInt24.swift */; };
+		6E069B7320E4FEE700669B76 /* UInt40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7220E4FEE700669B76 /* UInt40.swift */; };
+		6E069B7420E4FEE700669B76 /* UInt40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7220E4FEE700669B76 /* UInt40.swift */; };
+		6E069B7520E4FEE700669B76 /* UInt40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7220E4FEE700669B76 /* UInt40.swift */; };
+		6E069B7620E4FEE700669B76 /* UInt40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7220E4FEE700669B76 /* UInt40.swift */; };
 		6E124BC7207E553E0060E2E9 /* RSSI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E124BC6207E553E0060E2E9 /* RSSI.swift */; };
 		6E142480206CFFC500BF72BC /* HostController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E14247F206CFFC500BF72BC /* HostController.swift */; };
 		6E1F936720C213B60030367F /* ClassOfDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1F936620C213B60030367F /* ClassOfDevice.swift */; };
@@ -1535,7 +1543,6 @@
 		3580287820C8308E0096227B /* UnitIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitIdentifier.swift; sourceTree = "<group>"; };
 		3580287D20C832870096227B /* UnitIdentifierExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitIdentifierExtension.swift; sourceTree = "<group>"; };
 		35B7CADC20C5E72100F797AE /* GATTProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTProfile.swift; sourceTree = "<group>"; };
-		4B5C022820D834E10079C645 /* GATTBodyCompositionMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTBodyCompositionMeasurement.swift; sourceTree = "<group>"; };
 		35CA73CE20D9674D000E49F7 /* GATTBootMouseInputReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTBootMouseInputReport.swift; sourceTree = "<group>"; };
 		35CA73D820D96C0D000E49F7 /* GATTBootKeyboardInputReport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GATTBootKeyboardInputReport.swift; sourceTree = "<group>"; };
 		35CA73DA20D9735E000E49F7 /* GATTCentralAddressResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTCentralAddressResolution.swift; sourceTree = "<group>"; };
@@ -1544,12 +1551,15 @@
 		35CEF95620D869C2009E1688 /* GATTBootKeyboardOutputReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTBootKeyboardOutputReport.swift; sourceTree = "<group>"; };
 		35F5BB6620E406F000AC5FF1 /* GATTSerialNumberString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTSerialNumberString.swift; sourceTree = "<group>"; };
 		35F5BB6B20E4088400AC5FF1 /* GATTHardwareRevisionString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTHardwareRevisionString.swift; sourceTree = "<group>"; };
+		4B5C022820D834E10079C645 /* GATTBodyCompositionMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GATTBodyCompositionMeasurement.swift; sourceTree = "<group>"; };
 		511A657A2075B61400538116 /* LowEnergyResolvingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowEnergyResolvingList.swift; sourceTree = "<group>"; };
 		512F4B46208A562E00576F34 /* UInt256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt256.swift; sourceTree = "<group>"; };
 		512F4B4B208A567A00576F34 /* UInt512.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt512.swift; sourceTree = "<group>"; };
 		512F4B4D208B338500576F34 /* UInt256Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt256Tests.swift; sourceTree = "<group>"; };
 		512F4B4F208B339600576F34 /* UInt512Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt512Tests.swift; sourceTree = "<group>"; };
 		6E0245D720683DBD007FB15E /* HCIPacketHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HCIPacketHeader.swift; sourceTree = "<group>"; };
+		6E069B6D20E4FEDC00669B76 /* UInt24.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt24.swift; sourceTree = "<group>"; };
+		6E069B7220E4FEE700669B76 /* UInt40.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt40.swift; sourceTree = "<group>"; };
 		6E124BC6207E553E0060E2E9 /* RSSI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSI.swift; sourceTree = "<group>"; };
 		6E14247F206CFFC500BF72BC /* HostController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostController.swift; sourceTree = "<group>"; };
 		6E1A0C4C208006370095C29E /* DefinedUUIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinedUUIDTests.swift; sourceTree = "<group>"; };
@@ -2190,6 +2200,8 @@
 				6EE910241FDE5841007AD3EA /* UInt128.swift */,
 				512F4B46208A562E00576F34 /* UInt256.swift */,
 				512F4B4B208A567A00576F34 /* UInt512.swift */,
+				6E069B6D20E4FEDC00669B76 /* UInt24.swift */,
+				6E069B7220E4FEE700669B76 /* UInt40.swift */,
 				6E781B0920CE534300786867 /* SFloat.swift */,
 			);
 			name = "Numeric Data Types";
@@ -2677,6 +2689,7 @@
 				355BC23920D2C392001A07D3 /* HCILEEncrypt.swift in Sources */,
 				3518295720D22B8E0009F82D /* GAPIncompleteListOf32BitServiceClassUUIDs.swift in Sources */,
 				6E71F33420CB60D600D08901 /* GATTProfile.swift in Sources */,
+				6E069B7620E4FEE700669B76 /* UInt40.swift in Sources */,
 				6E9E4E86206DB68600D489E9 /* LowEnergyChannelMap.swift in Sources */,
 				355BC2C020D31600001A07D3 /* HCILESetPeriodicAdvertisingParameters.swift in Sources */,
 				355BC1FD20D2C2EA001A07D3 /* HCILESetAdvertisingParameters.swift in Sources */,
@@ -2789,6 +2802,7 @@
 				6E49B24A20532D45002EA5DC /* Range.swift in Sources */,
 				35182A2420D235520009F82D /* GATTAggregateFormatDescriptor.swift in Sources */,
 				6E6AADAE20D21DD100DDE1CA /* ATTMaximumTransmissionUnitResponse.swift in Sources */,
+				6E069B7120E4FEDC00669B76 /* UInt24.swift in Sources */,
 				356EB91B20D442370022A48D /* HCILEPeriodicAdvertisingSyncEstablished.swift in Sources */,
 				6E6AADA420D21C2700DDE1CA /* ATTErrorResponse.swift in Sources */,
 				35182A1F20D235480009F82D /* GATTServerCharacteristicConfiguration.swift in Sources */,
@@ -3012,6 +3026,7 @@
 				355BC23820D2C392001A07D3 /* HCILEEncrypt.swift in Sources */,
 				3518295620D22B8E0009F82D /* GAPIncompleteListOf32BitServiceClassUUIDs.swift in Sources */,
 				6E71F33320CB60D500D08901 /* GATTProfile.swift in Sources */,
+				6E069B7520E4FEE700669B76 /* UInt40.swift in Sources */,
 				6E9E4E85206DB68600D489E9 /* LowEnergyChannelMap.swift in Sources */,
 				355BC2BF20D31600001A07D3 /* HCILESetPeriodicAdvertisingParameters.swift in Sources */,
 				355BC1FC20D2C2EA001A07D3 /* HCILESetAdvertisingParameters.swift in Sources */,
@@ -3124,6 +3139,7 @@
 				6E704C891E95C41C00484A22 /* Range.swift in Sources */,
 				35182A2320D235520009F82D /* GATTAggregateFormatDescriptor.swift in Sources */,
 				6E6AADAD20D21DD100DDE1CA /* ATTMaximumTransmissionUnitResponse.swift in Sources */,
+				6E069B7020E4FEDC00669B76 /* UInt24.swift in Sources */,
 				356EB91A20D442370022A48D /* HCILEPeriodicAdvertisingSyncEstablished.swift in Sources */,
 				6E6AADA320D21C2700DDE1CA /* ATTErrorResponse.swift in Sources */,
 				35182A1E20D235480009F82D /* GATTServerCharacteristicConfiguration.swift in Sources */,
@@ -3497,6 +3513,7 @@
 				355BC2F420D3418A001A07D3 /* HCILEWriteRfPathCompensation.swift in Sources */,
 				6EB45EF02001398100AE5A42 /* DefinedUUID.swift in Sources */,
 				6E6AADB020D21FD800DDE1CA /* HCILESetEventMask.swift in Sources */,
+				6E069B7320E4FEE700669B76 /* UInt40.swift in Sources */,
 				355BC1FA20D2C2EA001A07D3 /* HCILESetAdvertisingParameters.swift in Sources */,
 				351829DB20D22DDF0009F82D /* GAPLERole.swift in Sources */,
 				355BC24020D2C3A5001A07D3 /* HCILELongTermKeyRequestReply.swift in Sources */,
@@ -3563,6 +3580,7 @@
 				6E6AAD7020D2161B00DDE1CA /* GATTBatteryLevel.swift in Sources */,
 				351829B320D22D840009F82D /* GAPServiceData16BitUUID.swift in Sources */,
 				356EB90920D4355C0022A48D /* HCILEDirectedAdvertisingReport.swift in Sources */,
+				6E069B6E20E4FEDC00669B76 /* UInt24.swift in Sources */,
 				356EB93B20D450190022A48D /* GATTAnaerobicHeartRateUpperLimit.swift in Sources */,
 				6E60A2F620695B6500E42351 /* LowEnergyConnection.swift in Sources */,
 				6E6AAE1720D258BA00DDE1CA /* ATTWriteRequest.swift in Sources */,
@@ -3716,6 +3734,7 @@
 				3518295520D22B8E0009F82D /* GAPIncompleteListOf32BitServiceClassUUIDs.swift in Sources */,
 				6E71F33220CB60D500D08901 /* GATTProfile.swift in Sources */,
 				6E9E4E84206DB68600D489E9 /* LowEnergyChannelMap.swift in Sources */,
+				6E069B7420E4FEE700669B76 /* UInt40.swift in Sources */,
 				355BC2BE20D31600001A07D3 /* HCILESetPeriodicAdvertisingParameters.swift in Sources */,
 				355BC1FB20D2C2EA001A07D3 /* HCILESetAdvertisingParameters.swift in Sources */,
 				6EF45FA41CC6D04D001F7A39 /* HCIEvent.swift in Sources */,
@@ -3828,6 +3847,7 @@
 				6E704C881E95C41C00484A22 /* Range.swift in Sources */,
 				35182A2220D235520009F82D /* GATTAggregateFormatDescriptor.swift in Sources */,
 				6E6AADAC20D21DD100DDE1CA /* ATTMaximumTransmissionUnitResponse.swift in Sources */,
+				6E069B6F20E4FEDC00669B76 /* UInt24.swift in Sources */,
 				356EB91920D442370022A48D /* HCILEPeriodicAdvertisingSyncEstablished.swift in Sources */,
 				6E6AADA220D21C2700DDE1CA /* ATTErrorResponse.swift in Sources */,
 				35182A1D20D235480009F82D /* GATTServerCharacteristicConfiguration.swift in Sources */,

--- a/Xcode/Bluetooth.xcodeproj/project.pbxproj
+++ b/Xcode/Bluetooth.xcodeproj/project.pbxproj
@@ -685,6 +685,8 @@
 		6E069B7420E4FEE700669B76 /* UInt40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7220E4FEE700669B76 /* UInt40.swift */; };
 		6E069B7520E4FEE700669B76 /* UInt40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7220E4FEE700669B76 /* UInt40.swift */; };
 		6E069B7620E4FEE700669B76 /* UInt40.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7220E4FEE700669B76 /* UInt40.swift */; };
+		6E069B8120E507EA00669B76 /* UInt40Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7720E5066800669B76 /* UInt40Tests.swift */; };
+		6E069B8220E507F900669B76 /* UInt24Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E069B7C20E5067900669B76 /* UInt24Tests.swift */; };
 		6E124BC7207E553E0060E2E9 /* RSSI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E124BC6207E553E0060E2E9 /* RSSI.swift */; };
 		6E142480206CFFC500BF72BC /* HostController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E14247F206CFFC500BF72BC /* HostController.swift */; };
 		6E1F936720C213B60030367F /* ClassOfDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1F936620C213B60030367F /* ClassOfDevice.swift */; };
@@ -1560,6 +1562,8 @@
 		6E0245D720683DBD007FB15E /* HCIPacketHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HCIPacketHeader.swift; sourceTree = "<group>"; };
 		6E069B6D20E4FEDC00669B76 /* UInt24.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt24.swift; sourceTree = "<group>"; };
 		6E069B7220E4FEE700669B76 /* UInt40.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt40.swift; sourceTree = "<group>"; };
+		6E069B7720E5066800669B76 /* UInt40Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt40Tests.swift; sourceTree = "<group>"; };
+		6E069B7C20E5067900669B76 /* UInt24Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UInt24Tests.swift; sourceTree = "<group>"; };
 		6E124BC6207E553E0060E2E9 /* RSSI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSI.swift; sourceTree = "<group>"; };
 		6E14247F206CFFC500BF72BC /* HostController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostController.swift; sourceTree = "<group>"; };
 		6E1A0C4C208006370095C29E /* DefinedUUIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefinedUUIDTests.swift; sourceTree = "<group>"; };
@@ -2157,6 +2161,8 @@
 				6E740C5D206586D3006589F6 /* HCITests.swift */,
 				6E65DF922075D29C005BD2A0 /* iBeaconTests.swift */,
 				6E4B733D20D95DD300FD6702 /* IntegerTests.swift */,
+				6E069B7C20E5067900669B76 /* UInt24Tests.swift */,
+				6E069B7720E5066800669B76 /* UInt40Tests.swift */,
 				6E65DF82207552E4005BD2A0 /* UInt128Tests.swift */,
 				512F4B4D208B338500576F34 /* UInt256Tests.swift */,
 				512F4B4F208B339600576F34 /* UInt512Tests.swift */,
@@ -3703,6 +3709,7 @@
 				6E443A0A2085D108005F4D5F /* TestProfile.swift in Sources */,
 				6E65DF952075D568005BD2A0 /* XCTest.swift in Sources */,
 				6E04273D20800B0700AD3C75 /* DefinedUUIDTests.swift in Sources */,
+				6E069B8120E507EA00669B76 /* UInt40Tests.swift in Sources */,
 				6E04273A208008A200AD3C75 /* BluetoothUUIDTests.swift in Sources */,
 				512F4B52208B341600576F34 /* UInt512Tests.swift in Sources */,
 				6E142480206CFFC500BF72BC /* HostController.swift in Sources */,
@@ -3710,6 +3717,7 @@
 				3531BF4C20CEEF8F00F31BC3 /* UnitIdentifierTests.swift in Sources */,
 				6E4B733E20D95DD300FD6702 /* IntegerTests.swift in Sources */,
 				6E7F4A4120928E2B00E877F1 /* GAPTests.swift in Sources */,
+				6E069B8220E507F900669B76 /* UInt24Tests.swift in Sources */,
 				6ECBCF0B206E683C00312117 /* L2CAPSocket.swift in Sources */,
 				6E30AE3720BF1A530072D101 /* GATTDescriptorTests.swift in Sources */,
 				6E6AD98D1FCE8E4F007F0250 /* BluetoothTests.swift in Sources */,


### PR DESCRIPTION
**Issue**

Implements #58. 

**What does this PR Do?**

Adds `UInt40` and `UInt24` integer types. Updates `GATTSystemID` to use the proper integer types and initialize from a Bluetooth Device Address.

**Where should the reviewer start?**

`GATTSystemID.swift`

**Sweet giphy showing how you feel about this PR**

![Giphy](https://i.gifer.com/BRao.gif)