### PR TITLE
Body Composition Measurement Unit fix

### DIFF
--- a/Sources/BluetoothGATT/GATTBodyCompositionMeasurement.swift
+++ b/Sources/BluetoothGATT/GATTBodyCompositionMeasurement.swift
@@ -149,9 +149,9 @@ public struct GATTBodyCompositionMeasurement: GATTCharacteristic {
         
         let flags = BitMaskOptionSet<Flag>(rawValue: UInt16(littleEndian: UInt16(bytes: (data[0], data[1]))))
         
-        massUnit = flags.contains(.measurementUnitSI) ? .kilogram : .pound
+        massUnit = flags.contains(.measurementUnitImperial) ? .pound : .kilogram
         
-        lengthUnit = flags.contains(.measurementUnitSI) ? .metre : .inch
+        lengthUnit = flags.contains(.measurementUnitImperial) ? .inch : .metre
         
         self.bodyFatPercentage = GATTBodyPercentage(rawValue: UInt16(littleEndian: UInt16(bytes: (data[2], data[3]))))
         


### PR DESCRIPTION
**Issue**

flags.contains(.measurementUnitSI) returns **false** even if the corresponding bit is 0

Fixes #1.

Updated the condition check and assigned the value accordingly

**What does this PR Do?**

Measurement unit condition check fix

**Where should the reviewer start?**

`main.swift`

**Sweet giphy showing how you feel about this PR**

![Giphy](https://media.giphy.com/media/rkDXJA9GoWR2/giphy.gif)
