### PR TITLE
Added a SPI manifest with an external documentation URL

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "http://pureswift.github.io/Bluetooth/documentation/bluetooth/"


### PR DESCRIPTION
**What does this PR Do?**

The PR adds a SPI manifest file that will add a "Documentation" link to the bottom of the sidebar menu to point people looking at this package on Swift Package Index to your self-hosted documentation. It will go here:

![Screenshot 2023-12-06 at 08 38 39@2x](https://github.com/PureSwift/Bluetooth/assets/5180/ae14c1a2-594c-4fc9-a1b7-d2989ed9c293)

Your package is just about to be featured on the new Swift.org Packages page, and I noticed you had self-hosted documentation. Thanks for making the package!