### PR TITLE
Deprecate `BitMaskOption`

### DIFF
--- a/.github/workflows/swift-arm.yml
+++ b/.github/workflows/swift-arm.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Swift Version
         run: swift --version
-      - name: Build
+      - name: Build Bluetooth
         run: swift build --triple armv6m-apple-none-macho --configuration release --verbose -Xswiftc -enable-experimental-feature -Xswiftc Embedded -Xswiftc -disable-stack-protector -Xcc -D__MACH__ -Xcc -ffreestanding -Xcc -mcpu=cortex-m0plus -Xcc -mthumb --target Bluetooth
-
+      - name: Build BluetoothGAP
+        run: swift build --triple armv6m-apple-none-macho --configuration release --verbose -Xswiftc -enable-experimental-feature -Xswiftc Embedded -Xswiftc -disable-stack-protector -Xcc -D__MACH__ -Xcc -ffreestanding -Xcc -mcpu=cortex-m0plus -Xcc -mthumb --target BluetoothGAP

--- a/Sources/Bluetooth/Address.swift
+++ b/Sources/Bluetooth/Address.swift
@@ -86,27 +86,29 @@ extension BluetoothAddress: ByteSwap {
 
 // MARK: - RawRepresentable
 
-#if !hasFeature(Embedded)
 extension BluetoothAddress: RawRepresentable {
     
     /// Initialize a Bluetooth Address from its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
     public init?(rawValue: String) {
         
         // verify string length
-        guard rawValue.utf8.count == 17
+        let characters = rawValue.utf8
+        guard characters.count == 17,
+            let separator = ":".utf8.first
             else { return nil }
         
         var bytes: ByteValue = (0, 0, 0, 0, 0, 0)
         
-        let components = rawValue.split(whereSeparator: { $0 == ":" })
+        let components = characters.split(whereSeparator: { $0 == separator })
         
         guard components.count == 6
             else { return nil }
         
-        for (index, string) in components.enumerated() {
+        for (index, subsequence) in components.enumerated() {
             
-            guard string.utf8.count == 2,
-                let byte = UInt8(string, radix: 16)
+            guard subsequence.count == 2,
+                  let string = String(subsequence),
+                  let byte = UInt8(hexadecimal: string)
                 else { return nil }
             
             withUnsafeMutablePointer(to: &bytes) {
@@ -121,19 +123,6 @@ extension BluetoothAddress: RawRepresentable {
     
     /// Convert a Bluetooth Address to its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
     public var rawValue: String {
-        _description
-    }
-}
-#endif
-
-// MARK: - CustomStringConvertible
-
-extension BluetoothAddress: CustomStringConvertible {
-    
-    public var description: String { _description }
-
-    /// Convert a Bluetooth Address to its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
-    internal var _description: String {
         let bytes = self.bigEndian.bytes
         return bytes.0.toHexadecimal()
             + ":" + bytes.1.toHexadecimal()
@@ -142,6 +131,13 @@ extension BluetoothAddress: CustomStringConvertible {
             + ":" + bytes.4.toHexadecimal()
             + ":" + bytes.5.toHexadecimal()
     }
+}
+
+// MARK: - CustomStringConvertible
+
+extension BluetoothAddress: CustomStringConvertible {
+    
+    public var description: String { rawValue }
 }
 
 // MARK: - Data

--- a/Sources/Bluetooth/Address.swift
+++ b/Sources/Bluetooth/Address.swift
@@ -90,6 +90,11 @@ extension BluetoothAddress: RawRepresentable {
     
     /// Initialize a Bluetooth Address from its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
     public init?(rawValue: String) {
+        self.init(rawValue)
+    }
+    
+    /// Initialize a Bluetooth Address from its big endian string representation (e.g. `00:1A:7D:DA:71:13`).
+    internal init?<S: StringProtocol>(_ rawValue: S) {
         
         // verify string length
         let characters = rawValue.utf8
@@ -107,8 +112,7 @@ extension BluetoothAddress: RawRepresentable {
         for (index, subsequence) in components.enumerated() {
             
             guard subsequence.count == 2,
-                  let string = String(subsequence),
-                  let byte = UInt8(hexadecimal: string)
+                  let byte = UInt8(hexadecimal: subsequence)
                 else { return nil }
             
             withUnsafeMutablePointer(to: &bytes) {

--- a/Sources/Bluetooth/BitMaskOption.swift
+++ b/Sources/Bluetooth/BitMaskOption.swift
@@ -9,6 +9,7 @@
 /// Enum that represents a bit mask flag / option.
 ///
 /// Basically `Swift.OptionSet` for enums.
+@available(*, deprecated, message: "Use OptionSet instead")
 public protocol BitMaskOption: RawRepresentable, Hashable, CaseIterable where RawValue: FixedWidthInteger { }
 
 public extension Sequence where Element: BitMaskOption {
@@ -40,7 +41,7 @@ public extension BitMaskOption {
 /// Integer-backed array type for `BitMaskOption`.
 ///
 /// The elements are packed in the integer with bitwise math and stored on the stack.
-@frozen
+@available(*, deprecated, message: "Use OptionSet instead")
 public struct BitMaskOptionSet <Element: BitMaskOption>: RawRepresentable {
     
     public typealias RawValue = Element.RawValue

--- a/Sources/Bluetooth/Extensions/Hexadecimal.swift
+++ b/Sources/Bluetooth/Extensions/Hexadecimal.swift
@@ -30,19 +30,17 @@ internal extension Collection where Element: FixedWidthInteger {
     }
 }
 
-internal extension UInt {
+internal extension FixedWidthInteger {
     
-    init?(parse string: String, radix: UInt) {
-        let digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        var result = UInt(0)
-        for digit in string {
-            #if hasFeature(Embedded)
-            let character = digit
-            #else
-            let character = String(digit).uppercased().first!
-            #endif
+    init?(parse string: String, radix: Self) {
+        #if !hasFeature(Embedded)
+        let string = string.uppercased()
+        #endif
+        let digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".utf8
+        var result = Self(0)
+        for character in string.utf8 {
             if let stringIndex = digits.enumerated().first(where: { $0.element == character })?.offset {
-                let val = UInt(stringIndex)
+                let val = Self(stringIndex)
                 if val >= radix {
                     return nil
                 }
@@ -55,14 +53,14 @@ internal extension UInt {
     }
 }
 
-internal extension UInt16 {
+internal extension FixedWidthInteger {
     
     init?(hexadecimal string: String) {
         guard string.utf8.count == MemoryLayout<Self>.size * 2 else {
             return nil
         }
         #if hasFeature(Embedded) || DEBUG
-        guard let value = UInt(parse: string, radix: 16) else {
+        guard let value = Self(parse: string, radix: 16) else {
             return nil
         }
         self.init(value)
@@ -72,23 +70,7 @@ internal extension UInt16 {
     }
 }
 
-internal extension UInt32 {
-    
-    init?(hexadecimal string: String) {
-        guard string.utf8.count == MemoryLayout<Self>.size * 2 else {
-            return nil
-        }
-        #if hasFeature(Embedded) || DEBUG
-        guard let value = UInt(parse: string, radix: 16) else {
-            return nil
-        }
-        self.init(value)
-        #else
-        self.init(string, radix: 16)
-        #endif
-    }
-}
-
+#if !hasFeature(Embedded)
 internal extension String.UTF16View.Element {
     
     // Convert 0 ... 9, a ... f, A ...F to their decimal value,
@@ -143,3 +125,4 @@ internal extension [UInt8] {
         
     }
 }
+#endif

--- a/Sources/Bluetooth/Extensions/Integer.swift
+++ b/Sources/Bluetooth/Extensions/Integer.swift
@@ -67,6 +67,15 @@ internal extension UInt8 {
     }
 }
 
+internal extension BinaryInteger {
+    
+    @inlinable
+    var bytes: [UInt8] {
+        var mutableValueCopy = self
+        return withUnsafeBytes(of: &mutableValueCopy) { Array($0) }
+    }
+}
+
 #if canImport(Foundation)
 internal extension UInt64 {
     

--- a/Sources/Bluetooth/Extensions/Integer.swift
+++ b/Sources/Bluetooth/Extensions/Integer.swift
@@ -14,13 +14,11 @@ internal extension UInt16 {
     
     /// Initializes value from two bytes.
     init(bytes: (UInt8, UInt8)) {
-        
         self = unsafeBitCast(bytes, to: UInt16.self)
     }
     
     /// Converts to two bytes. 
     var bytes: (UInt8, UInt8) {
-        
         return unsafeBitCast(self, to: (UInt8, UInt8).self)
     }
 }
@@ -29,13 +27,11 @@ internal extension UInt32 {
     
     /// Initializes value from four bytes.
     init(bytes: (UInt8, UInt8, UInt8, UInt8)) {
-        
         self = unsafeBitCast(bytes, to: UInt32.self)
     }
     
     /// Converts to four bytes.
     var bytes: (UInt8, UInt8, UInt8, UInt8) {
-        
         return unsafeBitCast(self, to: (UInt8, UInt8, UInt8, UInt8).self)
     }
 }
@@ -44,13 +40,11 @@ internal extension UInt64 {
     
     /// Initializes value from four bytes.
     init(bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) {
-        
         self = unsafeBitCast(bytes, to: UInt64.self)
     }
     
     /// Converts to eight bytes.
     var bytes: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) {
-        
         return unsafeBitCast(self, to: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8).self)
     }
 }
@@ -59,7 +53,6 @@ internal extension UInt8 {
     
     /// Initialize a byte from 2 bit enums.
     static func bit2(_ enum1: UInt8, _ enum2: UInt8, _ enum3: UInt8, _ enum4: UInt8) -> UInt8 {
-        
         var value: UInt8 = 0
         value += enum1 << 6
         value += enum2 << 4
@@ -70,7 +63,6 @@ internal extension UInt8 {
     
     /// Get 2 bit values from a byte.
     func bit2() -> (UInt8, UInt8, UInt8, UInt8) {
-        
         return (self >> 6, (self << 2) >> 6, (self << 4) >> 6, (self << 6) >> 6)
     }
 }

--- a/Sources/BluetoothGAP/Extensions/OptionSet.swift
+++ b/Sources/BluetoothGAP/Extensions/OptionSet.swift
@@ -1,0 +1,30 @@
+//
+//  OptionSet.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 11/5/24.
+//
+
+extension OptionSet {
+  @inline(never)
+  internal func buildDescription(
+    _ descriptions: [(Element, StaticString)]
+  ) -> String {
+    var copy = self
+    var result = "["
+
+    for (option, name) in descriptions {
+      if _slowPath(copy.contains(option)) {
+        result += name.description
+        copy.remove(option)
+        if !copy.isEmpty { result += ", " }
+      }
+    }
+
+    if _slowPath(!copy.isEmpty) {
+      result += "\(Self.self)(rawValue: \(copy.rawValue))"
+    }
+    result += "]"
+    return result
+  }
+}

--- a/Sources/BluetoothGAP/GAPDataType.swift
+++ b/Sources/BluetoothGAP/GAPDataType.swift
@@ -14,7 +14,7 @@
 /// - SeeAlso:
 /// [Generic Access Profile](https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile)
 @frozen
-public struct GAPDataType: RawRepresentable, Equatable, Hashable {
+public struct GAPDataType: RawRepresentable, Equatable, Hashable, Sendable {
     
     public var rawValue: UInt8
     
@@ -174,57 +174,67 @@ extension GAPDataType: ExpressibleByIntegerLiteral {
 
 // MARK: - CustomStringConvertible
 
+#if hasFeature(Embedded)
 extension GAPDataType: CustomStringConvertible {
     
-    public var name: String? {
-        return gapDataTypeNames[self]
+    public var description: String {
+        rawValue.description
     }
+}
+#else
+extension GAPDataType: CustomStringConvertible {
     
+    @inline(never)
     public var description: String {
         return name ?? "GAP Data Type (\(rawValue))"
     }
+    
+    @inline(never)
+    public var name: String? {
+        let names: [GAPDataType: String] = [
+            .flags: "Flags",
+            .incompleteListOf16BitServiceClassUUIDs: "Incomplete List of 16-bit Service Class UUIDs",
+            .completeListOf16CitServiceClassUUIDs: "Complete List of 16-bit Service Class UUIDs",
+            .incompleteListOf32BitServiceClassUUIDs: "Incomplete List of 32-bit Service Class UUIDs",
+            .completeListOf32BitServiceClassUUIDs: "Complete List of 32-bit Service Class UUIDs",
+            .incompleteListOf128BitServiceClassUUIDs: "Incomplete List of 128-bit Service Class UUIDs",
+            .completeListOf128BitServiceClassUUIDs: "Complete List of 128-bit Service Class UUIDs",
+            .shortLocalName: "Shortened Local Name",
+            .completeLocalName: "Complete Local Name",
+            .txPowerLevel: "Tx Power Level",
+            .classOfDevice: "Class of Device",
+            .simplePairingHashC: "Simple Pairing Hash C",
+            .simplePairingRandomizerR: "Simple Pairing Randomizer R",
+            .securityManagerTKValue: "Security Manager TK Value",
+            .securityManagerOutOfBandFlags: "Security Manager Out of Band Flags",
+            .slaveConnectionIntervalRange: "Slave Connection Interval Range",
+            .listOf16BitServiceSolicitationUUIDs: "List of 16-bit Service Solicitation UUIDs",
+            .listOf32BitServiceSolicitationUUIDs: "List of 32-bit Service Solicitation UUIDs",
+            .listOf128BitServiceSolicitationUUIDs: "List of 128-bit Service Solicitation UUIDs",
+            .serviceData16BitUUID: "Service Data - 16-bit UUID",
+            .serviceData32BitUUID: "Service Data - 32-bit UUID",
+            .serviceData128BitUUID: "Service Data - 128-bit UUID",
+            .publicTargetAddress: "Public Target Address",
+            .randomTargetAddress: "Random Target Address",
+            .appearance: "Appearance",
+            .advertisingInterval: "Advertising Interval",
+            .lowEnergyDeviceAddress: "LE Bluetooth Device Address",
+            .lowEnergyRole: "LE Role",
+            .lowEnergySecureConnectionsConfirmation: "LE Secure Connections Confirmation Value",
+            .lowEnergySecureConnectionsRandom: "LE Secure Connections Random Value",
+            .uri: "URI",
+            .indoorPositioning: "Indoor Positioning",
+            .transportDiscoveryData: "Transport Discovery Data",
+            .lowEnergySupportedFeatures: "LE Supported Features",
+            .channelMapUpdateIndication: "Channel Map Update Indication",
+            .pbAdv: "PB-ADV",
+            .meshMessage: "Mesh Message",
+            .meshBeacon: "Mesh Beacon",
+            .informationData3D: "3D Information Data",
+            .manufacturerSpecificData: "Manufacturer Specific Data"
+        ]
+        return names[self]
+    }
 }
 
-/// Standard GAP Data Type names
-internal let gapDataTypeNames: [GAPDataType: String] = [
-    .flags: "Flags",
-    .incompleteListOf16BitServiceClassUUIDs: "Incomplete List of 16-bit Service Class UUIDs",
-    .completeListOf16CitServiceClassUUIDs: "Complete List of 16-bit Service Class UUIDs",
-    .incompleteListOf32BitServiceClassUUIDs: "Incomplete List of 32-bit Service Class UUIDs",
-    .completeListOf32BitServiceClassUUIDs: "Complete List of 32-bit Service Class UUIDs",
-    .incompleteListOf128BitServiceClassUUIDs: "Incomplete List of 128-bit Service Class UUIDs",
-    .completeListOf128BitServiceClassUUIDs: "Complete List of 128-bit Service Class UUIDs",
-    .shortLocalName: "Shortened Local Name",
-    .completeLocalName: "Complete Local Name",
-    .txPowerLevel: "Tx Power Level",
-    .classOfDevice: "Class of Device",
-    .simplePairingHashC: "Simple Pairing Hash C",
-    .simplePairingRandomizerR: "Simple Pairing Randomizer R",
-    .securityManagerTKValue: "Security Manager TK Value",
-    .securityManagerOutOfBandFlags: "Security Manager Out of Band Flags",
-    .slaveConnectionIntervalRange: "Slave Connection Interval Range",
-    .listOf16BitServiceSolicitationUUIDs: "List of 16-bit Service Solicitation UUIDs",
-    .listOf32BitServiceSolicitationUUIDs: "List of 32-bit Service Solicitation UUIDs",
-    .listOf128BitServiceSolicitationUUIDs: "List of 128-bit Service Solicitation UUIDs",
-    .serviceData16BitUUID: "Service Data - 16-bit UUID",
-    .serviceData32BitUUID: "Service Data - 32-bit UUID",
-    .serviceData128BitUUID: "Service Data - 128-bit UUID",
-    .publicTargetAddress: "Public Target Address",
-    .randomTargetAddress: "Random Target Address",
-    .appearance: "Appearance",
-    .advertisingInterval: "Advertising Interval",
-    .lowEnergyDeviceAddress: "LE Bluetooth Device Address",
-    .lowEnergyRole: "LE Role",
-    .lowEnergySecureConnectionsConfirmation: "LE Secure Connections Confirmation Value",
-    .lowEnergySecureConnectionsRandom: "LE Secure Connections Random Value",
-    .uri: "URI",
-    .indoorPositioning: "Indoor Positioning",
-    .transportDiscoveryData: "Transport Discovery Data",
-    .lowEnergySupportedFeatures: "LE Supported Features",
-    .channelMapUpdateIndication: "Channel Map Update Indication",
-    .pbAdv: "PB-ADV",
-    .meshMessage: "Mesh Message",
-    .meshBeacon: "Mesh Beacon",
-    .informationData3D: "3D Information Data",
-    .manufacturerSpecificData: "Manufacturer Specific Data"
-]
+#endif

--- a/Tests/BluetoothTests/GAPTests.swift
+++ b/Tests/BluetoothTests/GAPTests.swift
@@ -26,10 +26,18 @@ final class GAPTests: XCTestCase {
         let flags: GAPFlags = [.lowEnergyGeneralDiscoverableMode, .notSupportedBREDR]
         
         XCTAssertEqual(flags, 0b00000110)
-        XCTAssertEqual(flags.flags, [.lowEnergyGeneralDiscoverableMode, .notSupportedBREDR])
-        XCTAssertEqual(flags.description, "[LE General Discoverable Mode, BR/EDR Not Supported]")
+        XCTAssertEqual(flags, [.lowEnergyGeneralDiscoverableMode, .notSupportedBREDR])
+        XCTAssertEqual(flags.description, "[.lowEnergyGeneralDiscoverableMode, .notSupportedBREDR]")
         
-        let allFlags = Array(GAPFlag.allCases).sorted(by: { $0.rawValue < $1.rawValue })
+        let allCases: [GAPFlags] = [
+            .lowEnergyLimitedDiscoverableMode,
+            .lowEnergyGeneralDiscoverableMode,
+            .notSupportedBREDR,
+            .simultaneousController,
+            .simultaneousHost
+        ]
+        
+        let allFlags = allCases.sorted(by: { $0.rawValue < $1.rawValue })
         allFlags.forEach { XCTAssertFalse($0.description.isEmpty) }
     }
     

--- a/Tests/BluetoothTests/UInt128Tests.swift
+++ b/Tests/BluetoothTests/UInt128Tests.swift
@@ -37,6 +37,27 @@ final class UInt128Tests: XCTestCase {
         XCTAssertNotEqual(Bluetooth.UInt128.max.hashValue, 0)
     }
     
+    func testHexadecimal() {
+        
+        var testData: [(UInt128, String)] = [
+            (.min,     "00000000000000000000000000000000"),
+            (.max,     "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+        ]
+        
+        if #available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *) {
+            testData += [
+                (0x60F14FE2F97211E5B84F23E070D5A8C7, "60F14FE2F97211E5B84F23E070D5A8C7")
+            ]
+        }
+        
+        for (value, hexadecimal) in testData {
+            XCTAssertEqual(value.hexadecimal, hexadecimal)
+            if #available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *) {
+                XCTAssertEqual(UInt128(parse: hexadecimal, radix: 16), value)
+            }
+        }
+    }
+    
     func testExpressibleByIntegerLiteral() {
         
         guard #available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *) else {

--- a/Tests/BluetoothTests/UInt24Tests.swift
+++ b/Tests/BluetoothTests/UInt24Tests.swift
@@ -38,16 +38,36 @@ final class UInt24Tests: XCTestCase {
         XCTAssertNotEqual(UInt24.max.hashValue, 0)
     }
     
+    func testHexadecimal() {
+        
+        let testData: [(UInt24, String)] = [
+            (.zero,     "000000"),
+            (0x000000,  "000000"),
+            (0x000001,  "000001"),
+            (0x000020,  "000020"),
+            (0xABCDEF,  "ABCDEF"),
+            (16777215,  "FFFFFF"),
+            (0xFFFFFF,  "FFFFFF"),
+            (.max,      "FFFFFF")
+        ]
+        
+        for (value, hexadecimal) in testData {
+            XCTAssertEqual(String(UInt32(value).toHexadecimal().suffix(6)), hexadecimal)
+            XCTAssertEqual(UInt32(hexadecimal, radix: 16), UInt32(value))
+            XCTAssertEqual(UInt32(parse: hexadecimal, radix: 16), UInt32(value))
+        }
+    }
+    
     func testExpressibleByIntegerLiteral() {
         
         let values: [(UInt24, String)] = [
-            (.zero, "000000"),
-            (0x000000, "000000"),
-            (0x000001, "000001"),
-            (0x000020, "000020"),
-            (0xABCDEF, "ABCDEF"),
-            (16777215, "FFFFFF"),
-            (0xFFFFFF, "FFFFFF")
+            (.zero,     "000000"),
+            (0x000000,  "000000"),
+            (0x000001,  "000001"),
+            (0x000020,  "000020"),
+            (0xABCDEF,  "ABCDEF"),
+            (16777215,  "FFFFFF"),
+            (0xFFFFFF,  "FFFFFF")
         ]
         
         values.forEach { XCTAssertEqual($0.description, $1) }


### PR DESCRIPTION
**Issue**

Addresses #139 and #154.

**What does this PR Do?**

Deprecates `BitMaskOption` and updates `GAPFlags` to use `OptionSet`
Also includes commits that improve Embedded Swift support.

**Where should the reviewer start?**

`BitMaskOption.swift`

**Sweet giphy showing how you feel about this PR**

![Giphy](https://media.giphy.com/media/rkDXJA9GoWR2/giphy.gif)
