### PR TITLE
fix package.swift depend url

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,7 +120,7 @@ if buildMetadata {
 if buildDocs {
     package.dependencies += [
         .package(
-            url: "https://github.com/apple/swift-docc-plugin",
+            url: "https://github.com/swiftlang/swift-docc-plugin.git",
             from: "1.0.0"
         )
     ]


### PR DESCRIPTION
fix depend url
`https://github.com/apple/swift-docc-plugin` -> `https://github.com/swiftlang/swift-docc-plugin.git`