### PR TITLE
Fix dependency version for Swift syntax package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -156,19 +156,13 @@ if generateCode {
 }
 
 if enableMacros {
-    let version: Version
-    #if swift(>=6.1)
-    version = "601.0.1"
-    #else
-    version = "600.0.1"
-    #endif
     package.targets[0].swiftSettings = [
         .define("SWIFTPM_ENABLE_MACROS")
     ]
     package.dependencies += [
         .package(
             url: "https://github.com/swiftlang/swift-syntax.git",
-            from: version
+            "600.0.1"..<"603.0.0"
         )
     ]
     package.targets += [


### PR DESCRIPTION
This makes it compatible with Swift 6.2 and more flexible