### PR TITLE
Mark DataContainer.subscript as mutating set

### DIFF
--- a/Sources/Bluetooth/Data.swift
+++ b/Sources/Bluetooth/Data.swift
@@ -18,7 +18,7 @@ public protocol DataContainer: RandomAccessCollection where Self.Index == Int, S
 
     mutating func reserveCapacity(_ capacity: Int)
 
-    subscript(index: Int) -> UInt8 { get }
+    subscript(index: Int) -> UInt8 { get mutating set }
 
     mutating func append(_ newElement: UInt8)
 


### PR DESCRIPTION
**What does this PR Do?**

DataContainer already allows mutating via the `append()` method, and all implementations of DataContainer (Foundation Data, UInt8 array, and LowEnergyAdvertisingData) support setting via the subscript notation, but it was not allowed on the generic type because this was marked as only allowing get access.