### PR TITLE
Fix typo: OBBData -> OOBData

### DIFF
--- a/Sources/BluetoothHCI/HCIIOCapabilityRequestReply.swift
+++ b/Sources/BluetoothHCI/HCIIOCapabilityRequestReply.swift
@@ -22,7 +22,7 @@ public extension BluetoothHostControllerInterface {
     func ioCapabilityRequestReply(
         address: BluetoothAddress,
         ioCapability: HCIIOCapabilityRequestReply.IOCapability,
-        obbDataPresent: HCIIOCapabilityRequestReply.OBBDataPresent,
+        oobDataPresent: HCIIOCapabilityRequestReply.OOBDataPresent,
         authenticationRequirements: HCIIOCapabilityRequestReply.AuthenticationRequirements,
         timeout: HCICommandTimeout = .default
     ) async throws -> BluetoothAddress {
@@ -30,7 +30,7 @@ public extension BluetoothHostControllerInterface {
         let command = HCIIOCapabilityRequestReply(
             address: address,
             ioCapability: ioCapability,
-            obbDataPresent: obbDataPresent,
+            oobDataPresent: oobDataPresent,
             authenticationRequirements: authenticationRequirements)
 
         return try await deviceRequest(command, HCIIOCapabilityRequestReplyReturn.self, timeout: timeout).address
@@ -54,20 +54,20 @@ public struct HCIIOCapabilityRequestReply: HCICommandParameter {
 
     public var ioCapability: IOCapability
 
-    public var obbDataPresent: OBBDataPresent
+    public var oobDataPresent: OOBDataPresent
 
     public var authenticationRequirements: AuthenticationRequirements
 
     public init(
         address: BluetoothAddress,
         ioCapability: IOCapability,
-        obbDataPresent: OBBDataPresent,
+        oobDataPresent: OOBDataPresent,
         authenticationRequirements: AuthenticationRequirements
     ) {
 
         self.address = address
         self.ioCapability = ioCapability
-        self.obbDataPresent = obbDataPresent
+        self.oobDataPresent = oobDataPresent
         self.authenticationRequirements = authenticationRequirements
     }
 
@@ -83,7 +83,7 @@ public struct HCIIOCapabilityRequestReply: HCICommandParameter {
             addressBytes.4,
             addressBytes.5,
             ioCapability.rawValue,
-            obbDataPresent.rawValue,
+            oobDataPresent.rawValue,
             authenticationRequirements.rawValue
         ])
     }
@@ -106,7 +106,7 @@ extension HCIIOCapabilityRequestReply {
         case noInputNoOutput = 0x03
     }
 
-    public enum OBBDataPresent: UInt8 {
+    public enum OOBDataPresent: UInt8 {
 
         /// OOB authentication data not present
         case oobDataNotPresent = 0x00

--- a/Sources/BluetoothHCI/HCIIOCapabilityResponse.swift
+++ b/Sources/BluetoothHCI/HCIIOCapabilityResponse.swift
@@ -13,7 +13,7 @@ import Foundation
 public struct HCIIOCapabilityResponse: HCIEventParameter {
 
     public typealias IOCapability = HCIIOCapabilityRequestReply.IOCapability
-    public typealias OBBDataPresent = HCIIOCapabilityRequestReply.OBBDataPresent
+    public typealias OOBDataPresent = HCIIOCapabilityRequestReply.OOBDataPresent
     public typealias AuthenticationRequirements = HCIIOCapabilityRequestReply.AuthenticationRequirements
 
     public static let event = HCIGeneralEvent.ioCapabilityResponse
@@ -24,7 +24,7 @@ public struct HCIIOCapabilityResponse: HCIEventParameter {
 
     public var ioCapability: IOCapability
 
-    public var obbDataPresent: OBBDataPresent
+    public var oobDataPresent: OOBDataPresent
 
     public var authenticationRequirements: AuthenticationRequirements
 
@@ -38,7 +38,7 @@ public struct HCIIOCapabilityResponse: HCIEventParameter {
         guard let ioCapability = IOCapability(rawValue: data[6])
         else { return nil }
 
-        guard let obbDataPresent = OBBDataPresent(rawValue: data[7])
+        guard let oobDataPresent = OOBDataPresent(rawValue: data[7])
         else { return nil }
 
         guard let authenticationRequirements = AuthenticationRequirements(rawValue: data[8])
@@ -46,7 +46,7 @@ public struct HCIIOCapabilityResponse: HCIEventParameter {
 
         self.address = address
         self.ioCapability = ioCapability
-        self.obbDataPresent = obbDataPresent
+        self.oobDataPresent = oobDataPresent
         self.authenticationRequirements = authenticationRequirements
     }
 }

--- a/Tests/BluetoothTests/HCITests.swift
+++ b/Tests/BluetoothTests/HCITests.swift
@@ -2961,7 +2961,7 @@ import Foundation
             return
         }
 
-        guard let dataPresent = HCIIOCapabilityRequestReply.OBBDataPresent(rawValue: 0x00)
+        guard let dataPresent = HCIIOCapabilityRequestReply.OOBDataPresent(rawValue: 0x00)
         else {
             Issue.record("Cannot init daatPresent")
             return
@@ -2976,7 +2976,7 @@ import Foundation
         let eventAddress = try await hostController.ioCapabilityRequestReply(
             address: address,
             ioCapability: ioCapability,
-            obbDataPresent: dataPresent,
+            oobDataPresent: dataPresent,
             authenticationRequirements: authenticationRequeriments
         )
         #expect(eventAddress == address)


### PR DESCRIPTION
**Issue**

There was inconsistency around OBB and OOB for "Out of Band" data.

**What does this PR Do?**

Renames `OBBDataPresent` to `OOBDataPresent`

**Where should the reviewer start?**

`HCIIOCapabilityRequestReply.swift`
