### PR TITLE
Update Package.swift environment variable access to use Context

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,13 @@
 // swift-tools-version:6.0
 import PackageDescription
 import CompilerPluginSupport
-import class Foundation.ProcessInfo
 
 // get environment variables
-let environment = ProcessInfo.processInfo.environment
-let dynamicLibrary = environment["SWIFT_BUILD_DYNAMIC_LIBRARY"] == "1"
-let buildMetadata = environment["SWIFTPM_BLUETOOTH_METADATA"] != "0"
-let generateCode = environment["SWIFTPM_ENABLE_PLUGINS"] != "0"
-let enableMacros = environment["SWIFTPM_ENABLE_MACROS"] != "0"
-let buildDocs = environment["BUILDING_FOR_DOCUMENTATION_GENERATION"] == "1"
+let dynamicLibrary = Context.environment["SWIFT_BUILD_DYNAMIC_LIBRARY"] == "1"
+let buildMetadata = Context.environment["SWIFTPM_BLUETOOTH_METADATA"] != "0"
+let generateCode = Context.environment["SWIFTPM_ENABLE_PLUGINS"] != "0"
+let enableMacros = Context.environment["SWIFTPM_ENABLE_MACROS"] != "0"
+let buildDocs = Context.environment["BUILDING_FOR_DOCUMENTATION_GENERATION"] == "1"
 
 // force building as dynamic library
 let libraryType: PackageDescription.Product.Library.LibraryType? = dynamicLibrary ? .dynamic : nil


### PR DESCRIPTION
Small fix to get rid of the need for `import class Foundation.ProcessInfo` in Package.swift.