### PR TITLE
Migrate GATTCharacteristic to DataConvertible

### DIFF
--- a/Sources/BluetoothGATT/GATTAerobicHeartRateLowerLimit.swift
+++ b/Sources/BluetoothGATT/GATTAerobicHeartRateLowerLimit.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Aerobic Heart Rate Lower Limit
@@ -40,9 +39,14 @@ public struct GATTAerobicHeartRateLowerLimit: GATTCharacteristic, Equatable, Has
         self.init(beats: beats)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([beats.rawValue])
+        data += beats.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTAerobicHeartRateUpperLimit.swift
+++ b/Sources/BluetoothGATT/GATTAerobicHeartRateUpperLimit.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Aerobic Heart Rate Upper Limit
@@ -40,9 +39,14 @@ public struct GATTAerobicHeartRateUpperLimit: GATTCharacteristic {
         self.init(beats: beats)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([beats.rawValue])
+        data += beats.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTAerobicThreshold.swift
+++ b/Sources/BluetoothGATT/GATTAerobicThreshold.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Aerobic Threshold
@@ -41,6 +40,10 @@ public struct GATTAerobicThreshold: GATTCharacteristic, Equatable, Hashable, Sen
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data.append(beats.rawValue)
+    }
+
+    public var dataLength: Int {
+        Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTAge.swift
+++ b/Sources/BluetoothGATT/GATTAge.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Age
@@ -38,9 +37,14 @@ public struct GATTAge: GATTCharacteristic, Equatable {
         self.init(year: year)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([year.rawValue])
+        data += year.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTAlertCategory.swift
+++ b/Sources/BluetoothGATT/GATTAlertCategory.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Categories of alerts/messages.
@@ -64,9 +63,14 @@ public enum GATTAlertCategory: UInt8, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTAlertCategoryBitMask.swift
+++ b/Sources/BluetoothGATT/GATTAlertCategoryBitMask.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Alert Category ID Bit Mask
@@ -35,9 +34,14 @@ public struct GATTAlertCategoryBitMask: GATTCharacteristic, Equatable, Hashable 
         self.categories = BitMaskOptionSet<Category>(rawValue: bitmask)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data(categories.rawValue.bitmaskArray)
+        data.append(contentsOf: categories.rawValue.bitmaskArray)
+    }
+
+    public var dataLength: Int {
+
+        return categories.rawValue.bitmaskArray.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTAlertLevel.swift
+++ b/Sources/BluetoothGATT/GATTAlertLevel.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Alert Level
@@ -50,8 +49,13 @@ public enum GATTAlertLevel: UInt8, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }

--- a/Sources/BluetoothGATT/GATTAlertNotificationControlPoint.swift
+++ b/Sources/BluetoothGATT/GATTAlertNotificationControlPoint.swift
@@ -62,16 +62,22 @@ public struct GATTAlertNotificationControlPoint: GATTCharacteristic {
         self.init(command: command, category: category)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([command.rawValue, category.rawValue])
+        data += command.rawValue
+        data += category.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
     public var characteristic: GATTAttribute<Data>.Characteristic {
 
         return GATTAttribute<Data>.Characteristic(
             uuid: Self.uuid,
-            value: data,
+            value: Data(self),
             permissions: [.read],
             properties: [.notify],
             descriptors: [])

--- a/Sources/BluetoothGATT/GATTAlertStatus.swift
+++ b/Sources/BluetoothGATT/GATTAlertStatus.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Alert Status
@@ -40,9 +39,14 @@ public struct GATTAlertStatus: GATTCharacteristic {
         self.states = BitMaskOptionSet<State>(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([states.rawValue])
+        data += states.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 extension GATTAlertStatus: Equatable {

--- a/Sources/BluetoothGATT/GATTAltitude.swift
+++ b/Sources/BluetoothGATT/GATTAltitude.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Altitude
@@ -36,10 +35,16 @@ public struct GATTAltitude: RawRepresentable, GATTCharacteristic, Equatable, Has
         self.init(rawValue: UInt16(littleEndian: UInt16(bytes: (data[0], data[1]))))
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = rawValue.littleEndian.bytes
-        return Data([bytes.0, bytes.1])
+        data += bytes.0
+        data += bytes.1
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTAnaerobicHeartRateLowerLimit.swift
+++ b/Sources/BluetoothGATT/GATTAnaerobicHeartRateLowerLimit.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Anaerobic Heart Rate Lower Limit
@@ -40,9 +39,14 @@ public struct GATTAnaerobicHeartRateLowerLimit: GATTCharacteristic, Equatable, H
         self.init(beats: beats)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([beats.rawValue])
+        data += beats.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTAnaerobicHeartRateUpperLimit.swift
+++ b/Sources/BluetoothGATT/GATTAnaerobicHeartRateUpperLimit.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Anaerobic Heart Rate Upper Limit
@@ -40,9 +39,14 @@ public struct GATTAnaerobicHeartRateUpperLimit: GATTCharacteristic, Equatable, H
         self.init(beats: beats)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([beats.rawValue])
+        data += beats.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTBarometricPressureTrend.swift
+++ b/Sources/BluetoothGATT/GATTBarometricPressureTrend.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Barometric Pressure Trend
@@ -59,9 +58,14 @@ public enum GATTBarometricPressureTrend: UInt8, GATTCharacteristic, BluetoothUni
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTBatteryLevel.swift
+++ b/Sources/BluetoothGATT/GATTBatteryLevel.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Battery Level
@@ -44,9 +43,14 @@ public extension GATTBatteryLevel {
         self.init(level: level)
     }
 
-    var data: Data {
+    func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([level.rawValue])
+        data += level.rawValue
+    }
+
+    var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTBatteryPowerState.swift
+++ b/Sources/BluetoothGATT/GATTBatteryPowerState.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Battery Power State
@@ -60,7 +59,7 @@ public struct GATTBatteryPowerState: GATTCharacteristic {
             levelState: levelState)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let byte = UInt8.bit2(
             presentState.rawValue,
@@ -68,7 +67,12 @@ public struct GATTBatteryPowerState: GATTCharacteristic {
             chargeState.rawValue,
             levelState.rawValue)
 
-        return Data([byte])
+        data += byte
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTBloodPressureFeature.swift
+++ b/Sources/BluetoothGATT/GATTBloodPressureFeature.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Blood Pressure Feature
@@ -38,11 +37,17 @@ public struct GATTBloodPressureFeature: GATTCharacteristic {
         self.init(features: features)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = features.rawValue.littleEndian.bytes
 
-        return Data([bytes.0, bytes.1])
+        data += bytes.0
+        data += bytes.1
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
     /// Blood Pressure Feature

--- a/Sources/BluetoothGATT/GATTBloodPressureMeasurement.swift
+++ b/Sources/BluetoothGATT/GATTBloodPressureMeasurement.swift
@@ -1,13 +1,11 @@
 //
-//  GATTBloodPressureManagement.swift
+//  GATTBloodPressureMeasurement.swift
 //  Bluetooth
 //
 //  Created by Carlos Duclos on 6/13/18.
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-import Bluetooth
 import Foundation
 import Bluetooth
 

--- a/Sources/BluetoothGATT/GATTBloodPressureMeasurement.swift
+++ b/Sources/BluetoothGATT/GATTBloodPressureMeasurement.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Blood Pressure Measurement
@@ -164,7 +163,7 @@ public struct GATTBloodPressureMeasurement: GATTCharacteristic {
         }
     }
 
-    public var data: Data {
+    public var dataLength: Int {
 
         let flags = self.flags
 
@@ -190,49 +189,48 @@ public struct GATTBloodPressureMeasurement: GATTCharacteristic {
             totalBytes += MemoryLayout<MeasurementStatus.RawValue>.size  // 2
         }
 
+        return totalBytes
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
         let systolicBytes = compoundValue.systolic.littleEndian.bitPattern.bytes
         let distolicBytes = compoundValue.diastolic.littleEndian.bitPattern.bytes
-        let meanArterialPressureBytes = compoundValue.meanArterialPressure.bitPattern.bytes
+        let meanArterialPressureBytes = compoundValue.meanArterialPressure.littleEndian.bitPattern.bytes
 
-        var data = Data([
-            flags.rawValue,
-            systolicBytes.0,
-            systolicBytes.1,
-            distolicBytes.0,
-            distolicBytes.1,
-            meanArterialPressureBytes.0,
-            meanArterialPressureBytes.1
-        ])
-
-        data.reserveCapacity(totalBytes)
+        data += flags.rawValue
+        data += systolicBytes.0
+        data += systolicBytes.1
+        data += distolicBytes.0
+        data += distolicBytes.1
+        data += meanArterialPressureBytes.0
+        data += meanArterialPressureBytes.1
 
         if let timestamp = self.timestamp {
 
-            data.append(timestamp.data)
+            timestamp.append(to: &data)
         }
 
         if let pulseRate = self.pulseRate {
 
             let bytes = pulseRate.littleEndian.bitPattern.bytes
 
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let userIdentifier = self.userIdentifier {
 
-            data.append(userIdentifier)
+            data += userIdentifier
         }
 
         if let measurementStatus = self.measurementStatus {
 
             let bytes = measurementStatus.rawValue.littleEndian.bytes
 
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
-
-        assert(data.count == totalBytes, "Encoded data is \(data.count), expected is \(totalBytes)")
-
-        return data
     }
 
     /// These flags define which data fields are present in the Characteristic value.

--- a/Sources/BluetoothGATT/GATTBodyCompositionMeasurement.swift
+++ b/Sources/BluetoothGATT/GATTBodyCompositionMeasurement.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Body Composition Measurement
@@ -307,7 +306,7 @@ public struct GATTBodyCompositionMeasurement: GATTCharacteristic {
         }
     }
 
-    public var data: Data {
+    public var dataLength: Int {
 
         let flags = self.flags
 
@@ -368,84 +367,92 @@ public struct GATTBodyCompositionMeasurement: GATTCharacteristic {
             totalBytes += MemoryLayout<UInt16>.size
         }
 
+        return totalBytes
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
         let flagBytes = flags.rawValue.littleEndian.bytes
         let bodyfatBytes = bodyFatPercentage.rawValue.littleEndian.bytes
 
-        var data = Data([
-            flagBytes.0,
-            flagBytes.1,
-            bodyfatBytes.0,
-            bodyfatBytes.1
-        ])
-
-        data.reserveCapacity(totalBytes)
+        data += flagBytes.0
+        data += flagBytes.1
+        data += bodyfatBytes.0
+        data += bodyfatBytes.1
 
         if let timestamp = self.timestamp {
 
-            data.append(timestamp.data)
+            timestamp.append(to: &data)
         }
 
         if let userIdentifier = self.userIdentifier {
 
-            data.append(userIdentifier)
+            data += userIdentifier
         }
 
         if let basalMetabolism = self.basalMetabolism {
 
             let bytes = basalMetabolism.rawValue.littleEndian.bytes
 
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let musclePercentage = self.musclePercentage {
 
             let bytes = musclePercentage.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let muscleMass = self.muscleMass {
 
             let bytes = muscleMass.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let fatFreeMass = self.fatFreeMass {
 
             let bytes = fatFreeMass.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let softleanMass = self.softLeanMass {
 
             let bytes = softleanMass.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let bodyWaterMass = self.bodyWaterMass {
 
             let bytes = bodyWaterMass.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let impedance = self.impedance {
 
             let bytes = impedance.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let weight = self.weight {
 
             let bytes = weight.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let height = self.height {
 
             let bytes = height.rawValue.littleEndian.bytes
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
-
-        return data
     }
 
     /// These flags define which data fields are present in the Characteristic value.

--- a/Sources/BluetoothGATT/GATTBodySensorLocation.swift
+++ b/Sources/BluetoothGATT/GATTBodySensorLocation.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Body Sensor Location
@@ -48,9 +47,14 @@ public enum GATTBodySensorLocation: UInt8, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTBootKeyboardInputReport.swift
+++ b/Sources/BluetoothGATT/GATTBootKeyboardInputReport.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Boot Keyboard Input Report
@@ -36,9 +35,14 @@ public struct GATTBootKeyboardInputReport: RawRepresentable, GATTCharacteristic 
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTBootKeyboardOutputReport.swift
+++ b/Sources/BluetoothGATT/GATTBootKeyboardOutputReport.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Boot Keyboard Output Report
@@ -36,9 +35,14 @@ public struct GATTBootKeyboardOutputReport: RawRepresentable, GATTCharacteristic
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTBootMouseInputReport.swift
+++ b/Sources/BluetoothGATT/GATTBootMouseInputReport.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Boot Mouse Input Report
@@ -36,9 +35,14 @@ public struct GATTBootMouseInputReport: RawRepresentable, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTCGMSessionRunTime.swift
+++ b/Sources/BluetoothGATT/GATTCGMSessionRunTime.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// CGM Session Run Time
@@ -51,14 +50,9 @@ public struct GATTCGMSessionRunTime: GATTCharacteristic {
         self.init(sessionRunTime: sessionRunTime, e2ecrc: e2ecrc)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let sessionRunTimeBytes = sessionRunTime.rawValue.littleEndian.bytes
-
-        let totalBytes = e2ecrc != nil ? Self.maxLength : Self.minLength
-
-        var data = Data()
-        data.reserveCapacity(totalBytes)
 
         data += [sessionRunTimeBytes.0, sessionRunTimeBytes.1]
 
@@ -66,8 +60,11 @@ public struct GATTCGMSessionRunTime: GATTCharacteristic {
 
             data += [e2ecrcBytes.0, e2ecrcBytes.1]
         }
+    }
 
-        return data
+    public var dataLength: Int {
+
+        return e2ecrc != nil ? Self.maxLength : Self.minLength
     }
 }
 

--- a/Sources/BluetoothGATT/GATTCentralAddressResolution.swift
+++ b/Sources/BluetoothGATT/GATTCentralAddressResolution.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Central Address Resolution
@@ -46,9 +45,14 @@ public struct GATTCentralAddressResolution: GATTCharacteristic {
         self.init(isSupported: booleanValue)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([isSupported.byteValue])
+        data += isSupported.byteValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTCharacteristic.swift
+++ b/Sources/BluetoothGATT/GATTCharacteristic.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import Bluetooth
-import Foundation
 
 /// GATT Characteristic protocol.
 ///

--- a/Sources/BluetoothGATT/GATTCharacteristic.swift
+++ b/Sources/BluetoothGATT/GATTCharacteristic.swift
@@ -6,13 +6,12 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// GATT Characteristic protocol.
 ///
 /// Describes a type that can encode / decode data to a characteristic type.
-public protocol GATTCharacteristic: DeprecatedGATTCharacteristic {
+public protocol GATTCharacteristic: DataConvertible {
 
     /// The Bluetooth UUID of the characteristic.
     static var uuid: BluetoothUUID { get }
@@ -22,33 +21,4 @@ public protocol GATTCharacteristic: DeprecatedGATTCharacteristic {
 
     /// Append data representation into buffer.
     func append<Data: DataContainer>(to data: inout Data)
-}
-
-public extension DataContainer {
-
-    /// Initialize data with contents of value.
-    init<T: GATTCharacteristic>(_ value: T) {
-        self.init()
-        value.append(to: &self)
-    }
-}
-
-public protocol DeprecatedGATTCharacteristic {
-
-    init?(data: Data)
-
-    var data: Data { get }
-}
-
-public extension GATTCharacteristic {
-
-    // TODO: Remove Foundation.Data Usage
-    var data: Data {
-        Data(self)
-    }
-
-    // TODO: Should implement at least one of these
-    func append<Data: DataContainer>(to data: inout Data) {
-        data += self.data
-    }
 }

--- a/Sources/BluetoothGATT/GATTCrossTrainerData.swift
+++ b/Sources/BluetoothGATT/GATTCrossTrainerData.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 /// Cross Trainer Data
 ///
@@ -14,7 +13,7 @@ import Bluetooth
 ///
 /// - SeeAlso: [Cross Trainer Data](https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.characteristic.cross_trainer_data.xml)
 @frozen
-public struct GATTCrossTrainerData {
+public struct GATTCrossTrainerData: GATTCharacteristic {
 
     internal static let minimumLength = MemoryLayout<UInt24>.size
 
@@ -408,7 +407,7 @@ public struct GATTCrossTrainerData {
         }
     }
 
-    public var data: Data {
+    public var dataLength: Int {
 
         let flags = self.flags
 
@@ -466,7 +465,7 @@ public struct GATTCrossTrainerData {
 
         if flags.contains(.expendedEnergy) {
 
-            totalBytes += GATTKilogramCalorie.Byte.length
+            totalBytes += GATTKilogramCalorie.Bits16.length * 2 + GATTKilogramCalorie.Byte.length
         }
 
         if flags.contains(.heartRate) {
@@ -489,21 +488,23 @@ public struct GATTCrossTrainerData {
             totalBytes += Time.length
         }
 
+        return totalBytes
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
         let flagBytes = flags.rawValue.littleEndian.bytes
 
-        var data = Data([
-            flagBytes.0,
-            flagBytes.1,
-            flagBytes.2
-        ])
-
-        data.reserveCapacity(totalBytes)
+        data += flagBytes.0
+        data += flagBytes.1
+        data += flagBytes.2
 
         if let instantaneousSpeed = self.instantaneousSpeed {
 
             let bytes = instantaneousSpeed.rawValue.littleEndian.bytes
 
-            data += [bytes.0, bytes.1]
+            data += bytes.0
+            data += bytes.1
         }
 
         if let averageSpeed = self.averageSpeed {
@@ -632,8 +633,6 @@ public struct GATTCrossTrainerData {
 
             data += [bytes.0, bytes.1]
         }
-
-        return data
     }
 
     /// These flags define which data fields are present in the Characteristic value.

--- a/Sources/BluetoothGATT/GATTCurrentTime.swift
+++ b/Sources/BluetoothGATT/GATTCurrentTime.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Current Time
@@ -42,9 +41,15 @@ public struct GATTCurrentTime: GATTCharacteristic, Equatable {
         self.init(exactTime: exactTime, adjustReason: adjustReason)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return exactTime.data + Data([adjustReason.rawValue])
+        exactTime.append(to: &data)
+        data += adjustReason.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTDateUTC.swift
+++ b/Sources/BluetoothGATT/GATTDateUTC.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 @frozen
@@ -34,11 +33,17 @@ public struct GATTDateUTC: GATTCharacteristic, Equatable {
         self.init(date: date)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = date.rawValue.littleEndian.bytes
+        data += bytes.0
+        data += bytes.1
+        data += bytes.2
+    }
 
-        return Data([bytes.0, bytes.1, bytes.2])
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTDayDateTime.swift
+++ b/Sources/BluetoothGATT/GATTDayDateTime.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Day Date Time
@@ -43,9 +42,15 @@ public struct GATTDayDateTime: GATTCharacteristic {
         self.init(dateTime: dateTime, dayOfWeek: dayOfWeek)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return dateTime.data + dayOfWeek.data
+        dateTime.append(to: &data)
+        dayOfWeek.append(to: &data)
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTDayOfWeek.swift
+++ b/Sources/BluetoothGATT/GATTDayOfWeek.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Day of Week
@@ -37,9 +36,14 @@ public struct GATTDayOfWeek: GATTCharacteristic {
         self.init(day: day)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([day.rawValue])
+        data += day.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTDstOffset.swift
+++ b/Sources/BluetoothGATT/GATTDstOffset.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// DST Offset
@@ -42,9 +41,14 @@ public enum GATTDstOffset: UInt8, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTExactTime256.swift
+++ b/Sources/BluetoothGATT/GATTExactTime256.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Exact Time 256
@@ -42,9 +41,15 @@ public struct GATTExactTime256: GATTCharacteristic {
         self.init(dayDateTime: dayDateTime, fractions256: fractions256)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return dayDateTime.data + Data([fractions256])
+        dayDateTime.append(to: &data)
+        data += fractions256
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTFirmwareRevisionString.swift
+++ b/Sources/BluetoothGATT/GATTFirmwareRevisionString.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /*+
@@ -37,6 +36,10 @@ public struct GATTFirmwareRevisionString: RawRepresentable, GATTCharacteristic, 
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
+    }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTFloorNumber.swift
+++ b/Sources/BluetoothGATT/GATTFloorNumber.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Floor Number
@@ -36,9 +35,14 @@ public struct GATTFloorNumber: RawRepresentable, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTHardwareRevisionString.swift
+++ b/Sources/BluetoothGATT/GATTHardwareRevisionString.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Hardware Revision String
@@ -35,6 +34,10 @@ public struct GATTHardwareRevisionString: RawRepresentable, Equatable, Hashable,
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
+    }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTIndoorPositioningConfiguration.swift
+++ b/Sources/BluetoothGATT/GATTIndoorPositioningConfiguration.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Indoor Positioning Configuration
@@ -36,9 +35,14 @@ public struct GATTIndoorPositioningConfiguration: GATTCharacteristic {
         self.init(configurations: BitMaskOptionSet<Configuration>(rawValue: data[0]))
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([configurations.rawValue])
+        data += configurations.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTLatitude.swift
+++ b/Sources/BluetoothGATT/GATTLatitude.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Latitude
@@ -36,10 +35,15 @@ public struct GATTLatitude: RawRepresentable, GATTCharacteristic {
         self.init(rawValue: Int32(bitPattern: UInt32(littleEndian: UInt32(bytes: (data[0], data[1], data[2], data[3])))))
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = UInt32(bitPattern: rawValue).littleEndian.bytes
-        return Data([bytes.0, bytes.1, bytes.2, bytes.3])
+        data += [bytes.0, bytes.1, bytes.2, bytes.3]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTLocalEastCoordinate.swift
+++ b/Sources/BluetoothGATT/GATTLocalEastCoordinate.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Local East Coordinate
@@ -36,10 +35,15 @@ public struct GATTLocalEastCoordinate: RawRepresentable, GATTCharacteristic {
         self.init(rawValue: Int16(bitPattern: UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))))
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = UInt16(bitPattern: rawValue).littleEndian.bytes
-        return Data([bytes.0, bytes.1])
+        data += [bytes.0, bytes.1]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTLocalNorthCoordinate.swift
+++ b/Sources/BluetoothGATT/GATTLocalNorthCoordinate.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Local North Coordinate
@@ -36,10 +35,15 @@ public struct GATTLocalNorthCoordinate: RawRepresentable, GATTCharacteristic {
         self.init(rawValue: Int16(bitPattern: UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))))
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = UInt16(bitPattern: rawValue).littleEndian.bytes
-        return Data([bytes.0, bytes.1])
+        data += [bytes.0, bytes.1]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTLocalTimeInformation.swift
+++ b/Sources/BluetoothGATT/GATTLocalTimeInformation.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Local Time Information
@@ -43,8 +42,14 @@ public struct GATTLocalTimeInformation: GATTCharacteristic, Equatable {
         self.init(timeZone: timeZone, dstOffset: dstOffset)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return timeZone.data + dstOffset.data
+        timeZone.append(to: &data)
+        dstOffset.append(to: &data)
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }

--- a/Sources/BluetoothGATT/GATTLocationName.swift
+++ b/Sources/BluetoothGATT/GATTLocationName.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Location Name
@@ -36,6 +35,10 @@ public struct GATTLocationName: RawRepresentable, GATTCharacteristic {
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
+    }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTLongitude.swift
+++ b/Sources/BluetoothGATT/GATTLongitude.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Longitude
@@ -36,10 +35,15 @@ public struct GATTLongitude: RawRepresentable, GATTCharacteristic {
         self.init(rawValue: Int32(bitPattern: UInt32(littleEndian: UInt32(bytes: (data[0], data[1], data[2], data[3])))))
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = UInt32(bitPattern: rawValue).littleEndian.bytes
-        return Data([bytes.0, bytes.1, bytes.2, bytes.3])
+        data += [bytes.0, bytes.1, bytes.2, bytes.3]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTManufacturerNameString.swift
+++ b/Sources/BluetoothGATT/GATTManufacturerNameString.swift
@@ -33,6 +33,10 @@ public struct GATTManufacturerNameString: GATTCharacteristic, Hashable, Sendable
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
     }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
+    }
 }
 
 extension GATTManufacturerNameString: CustomStringConvertible {

--- a/Sources/BluetoothGATT/GATTModelNumber.swift
+++ b/Sources/BluetoothGATT/GATTModelNumber.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Model Number String
@@ -36,6 +35,10 @@ public struct GATTModelNumber: RawRepresentable, GATTCharacteristic {
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
+    }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTNewAlert.swift
+++ b/Sources/BluetoothGATT/GATTNewAlert.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// New Alert
@@ -68,9 +67,16 @@ public struct GATTNewAlert: GATTCharacteristic, Equatable {
             information: information)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([category.rawValue, newAlertsCount]) + information.data
+        data += category.rawValue
+        data += newAlertsCount
+        information.append(to: &data)
+    }
+
+    public var dataLength: Int {
+
+        return Self.minLength + information.dataLength
     }
 }
 
@@ -108,12 +114,14 @@ public extension GATTNewAlert {
             self.init(rawValue: string)
         }
 
-        public var data: Data {
+        public func append<Data: DataContainer>(to data: inout Data) {
 
-            guard let data = rawValue.data(using: .utf8)
-            else { fatalError("Could not encode string") }
+            data += rawValue.utf8
+        }
 
-            return data
+        public var dataLength: Int {
+
+            return rawValue.utf8.count
         }
     }
 }

--- a/Sources/BluetoothGATT/GATTObjectID.swift
+++ b/Sources/BluetoothGATT/GATTObjectID.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Object ID
@@ -44,11 +43,16 @@ public struct GATTObjectID: Equatable, RawRepresentable, GATTCharacteristic {
         self.init(rawValue: rawValue)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = rawValue.littleEndian.bytes
 
-        return Data([bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5])
+        data += [bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTObjectName.swift
+++ b/Sources/BluetoothGATT/GATTObjectName.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Object Name
@@ -43,6 +42,10 @@ public struct GATTObjectName: Equatable, Hashable, RawRepresentable, GATTCharact
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
+    }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTObjectSize.swift
+++ b/Sources/BluetoothGATT/GATTObjectSize.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Object Size
@@ -41,12 +40,12 @@ public struct GATTObjectSize: GATTCharacteristic, Equatable {
         self.init(currentSize: currentSize, allocatedSize: allocatedSize)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let currentSizeBytes = currentSize.rawValue.littleEndian.bytes
         let allocatedSizeBytes = allocatedSize.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             currentSizeBytes.0,
             currentSizeBytes.1,
             currentSizeBytes.2,
@@ -55,7 +54,12 @@ public struct GATTObjectSize: GATTCharacteristic, Equatable {
             allocatedSizeBytes.1,
             allocatedSizeBytes.2,
             allocatedSizeBytes.3
-        ])
+        ]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTObjectType.swift
+++ b/Sources/BluetoothGATT/GATTObjectType.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Object Type
@@ -38,11 +37,16 @@ public struct GATTObjectType: Equatable, Hashable, RawRepresentable, GATTCharact
         self.init(rawValue: rawValue)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = rawValue.littleEndian.bytes
 
-        return Data([bytes.0, bytes.1])
+        data += [bytes.0, bytes.1]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTPnPID.swift
+++ b/Sources/BluetoothGATT/GATTPnPID.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// PnP ID
@@ -60,7 +59,7 @@ public struct GATTPnPID: GATTCharacteristic {
         self.init(vendorIdSource: vendorIdSource, vendorId: vendorId, productId: productId, productVersion: productVersion)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let vendorIdBytes = vendorId.littleEndian.bytes
 
@@ -68,7 +67,12 @@ public struct GATTPnPID: GATTCharacteristic {
 
         let productVersionBytes = productVersion.littleEndian.bytes
 
-        return Data([vendorIdSource.rawValue, vendorIdBytes.0, vendorIdBytes.1, productIdBytes.0, productIdBytes.1, productVersionBytes.0, productVersionBytes.1])
+        data += [vendorIdSource.rawValue, vendorIdBytes.0, vendorIdBytes.1, productIdBytes.0, productIdBytes.1, productVersionBytes.0, productVersionBytes.1]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTReferenceTimeInformation.swift
+++ b/Sources/BluetoothGATT/GATTReferenceTimeInformation.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Reference Time Information
@@ -63,9 +62,17 @@ public struct GATTReferenceTimeInformation: GATTCharacteristic, Equatable {
             hoursSinceUpdate: hoursSinceUpdate)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return timeSource.data + timeAccuracy.data + Data([daysSinceUpdate.rawValue]) + Data([hoursSinceUpdate.rawValue])
+        timeSource.append(to: &data)
+        timeAccuracy.append(to: &data)
+        data += daysSinceUpdate.rawValue
+        data += hoursSinceUpdate.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTScanIntervalWindow.swift
+++ b/Sources/BluetoothGATT/GATTScanIntervalWindow.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Scan Interval Window
@@ -50,12 +49,17 @@ public struct GATTScanIntervalWindow: GATTCharacteristic {
         self.init(scanInterval: scanInterval, scanWindow: scanWindow)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let scanIntervalBytes = scanInterval.rawValue.littleEndian.bytes
         let scanWindowBytes = scanWindow.rawValue.littleEndian.bytes
 
-        return Data([scanIntervalBytes.0, scanIntervalBytes.1, scanWindowBytes.0, scanWindowBytes.1])
+        data += [scanIntervalBytes.0, scanIntervalBytes.1, scanWindowBytes.0, scanWindowBytes.1]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTScanRefresh.swift
+++ b/Sources/BluetoothGATT/GATTScanRefresh.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Scan Refresh
@@ -31,9 +30,14 @@ public enum GATTScanRefresh: UInt8, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTSerialNumberString.swift
+++ b/Sources/BluetoothGATT/GATTSerialNumberString.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Serial Number String
@@ -36,6 +35,10 @@ public struct GATTSerialNumberString: RawRepresentable, GATTCharacteristic {
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
+    }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTSoftwareRevisionString.swift
+++ b/Sources/BluetoothGATT/GATTSoftwareRevisionString.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Software Revision String
@@ -36,6 +35,10 @@ public struct GATTSoftwareRevisionString: RawRepresentable, GATTCharacteristic {
 
     public func append<Data>(to data: inout Data) where Data: DataContainer {
         data += rawValue.utf8
+    }
+
+    public var dataLength: Int {
+        rawValue.utf8.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTSupportedNewAlertCategory.swift
+++ b/Sources/BluetoothGATT/GATTSupportedNewAlertCategory.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Supported New Alert Category
@@ -42,9 +41,14 @@ public struct GATTSupportedNewAlertCategory: GATTCharacteristic {
         self.categories = BitMaskOptionSet<Category>(rawValue: bitmask)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data(categories.rawValue.bitmaskArray)
+        data.append(contentsOf: categories.rawValue.bitmaskArray)
+    }
+
+    public var dataLength: Int {
+
+        return categories.rawValue.bitmaskArray.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTSupportedUnreadAlertCategory.swift
+++ b/Sources/BluetoothGATT/GATTSupportedUnreadAlertCategory.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Supported Unread Alert Category
@@ -41,9 +40,14 @@ public struct GATTSupportedUnreadAlertCategory: GATTCharacteristic {
         self.categories = BitMaskOptionSet<Category>(rawValue: bitmask)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data(categories.rawValue.bitmaskArray)
+        data.append(contentsOf: categories.rawValue.bitmaskArray)
+    }
+
+    public var dataLength: Int {
+
+        return categories.rawValue.bitmaskArray.count
     }
 }
 

--- a/Sources/BluetoothGATT/GATTSystemID.swift
+++ b/Sources/BluetoothGATT/GATTSystemID.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// System ID
@@ -103,11 +102,11 @@ public struct GATTSystemID: GATTCharacteristic, RawRepresentable, Equatable, Has
         self.init(rawValue: rawValue)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             bytes.0,
             bytes.1,
             bytes.2,
@@ -116,7 +115,12 @@ public struct GATTSystemID: GATTCharacteristic, RawRepresentable, Equatable, Has
             bytes.5,
             bytes.6,
             bytes.7
-        ])
+        ]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTTimeAccuracy.swift
+++ b/Sources/BluetoothGATT/GATTTimeAccuracy.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Time Accuracy
@@ -40,9 +39,14 @@ public struct GATTTimeAccuracy: RawRepresentable, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTTimeSource.swift
+++ b/Sources/BluetoothGATT/GATTTimeSource.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Time Source
@@ -48,9 +47,14 @@ public enum GATTTimeSource: UInt8, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTTimeUpdateControlPoint.swift
+++ b/Sources/BluetoothGATT/GATTTimeUpdateControlPoint.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Time Update Control Point
@@ -33,8 +32,13 @@ public enum GATTTimeUpdateControlPoint: UInt8, GATTCharacteristic {
         self.init(rawValue: data[0])
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rawValue])
+        data += rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }

--- a/Sources/BluetoothGATT/GATTTimeUpdateState.swift
+++ b/Sources/BluetoothGATT/GATTTimeUpdateState.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Time Update State
@@ -43,9 +42,15 @@ public struct GATTTimeUpdateState: GATTCharacteristic, Equatable {
         self.init(currentState: currentState, result: result)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([currentState.rawValue, result.rawValue])
+        data += currentState.rawValue
+        data += result.rawValue
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTTimeWithDst.swift
+++ b/Sources/BluetoothGATT/GATTTimeWithDst.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Time with DST
@@ -43,8 +42,14 @@ public struct GATTTimeWithDst: GATTCharacteristic, Equatable {
         self.init(datetime: datetime, dstOffset: dstOffset)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return datetime.data + dstOffset.data
+        datetime.append(to: &data)
+        dstOffset.append(to: &data)
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }

--- a/Sources/BluetoothGATT/GATTTimeZone.swift
+++ b/Sources/BluetoothGATT/GATTTimeZone.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Time Zone
@@ -55,11 +54,14 @@ public struct GATTTimeZone: RawRepresentable, GATTCharacteristic, Equatable, Has
         self.init(rawValue: level)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        let byteValue = UInt8(bitPattern: rawValue)
+        data += UInt8(bitPattern: rawValue)
+    }
 
-        return Data([byteValue])
+    public var dataLength: Int {
+
+        return Self.length
     }
 
 }

--- a/Sources/BluetoothGATT/GATTUncertainty.swift
+++ b/Sources/BluetoothGATT/GATTUncertainty.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Uncertainty
@@ -47,11 +46,14 @@ public struct GATTUncertainty: GATTCharacteristic {
         self.init(stationary: stationary, updateTime: updateTime, precision: precision)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        let byte = stationary.rawValue | (updateTime.rawValue << 1) | (precision.rawValue << 4)
+        data += stationary.rawValue | (updateTime.rawValue << 1) | (precision.rawValue << 4)
+    }
 
-        return Data([byte])
+    public var dataLength: Int {
+
+        return Self.length
     }
 }
 

--- a/Sources/BluetoothGATT/GATTUnreadAlertStatus.swift
+++ b/Sources/BluetoothGATT/GATTUnreadAlertStatus.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 /// Unread Alert Status
@@ -54,8 +53,14 @@ public struct GATTUnreadAlertStatus: GATTCharacteristic {
         self.init(category: category, unreadCount: unreadCount)
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([category.rawValue, unreadCount])
+        data += category.rawValue
+        data += unreadCount
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
     }
 }

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -69,7 +69,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.year == .unknown)
             #expect(characteristic.month == .unknown)
             #expect(characteristic.day == .unknown)
@@ -89,7 +89,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.year.rawValue == 1995)
             #expect(characteristic.month == .april)
             #expect(characteristic.day.rawValue == 24)
@@ -116,7 +116,7 @@ import Bluetooth
         }
 
         // test characteristic
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.level == percentage)
         #expect(characteristic.description == "34%")
         #expect(GATTBatteryLevel(level: percentage) != nil)
@@ -144,7 +144,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.categories == [.call, .email], "The value 0x0a is interpreted that this server supports “Call” and “Email” categories.")
     }
 
@@ -158,7 +158,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.categories == [.simpleAlert, .email], "The value 0x03 is interpreted as “Simple Alert and Email bits set")
     }
 
@@ -174,7 +174,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
 
         // The value 0x01, 0x04, 0x52, 0x69, 0x63, 0x68, 0x61, 0x72, 0x64 are interpreted that the server has 4 new email messages and the last message was sent by “Richard”.
         #expect(characteristic.category == .email)
@@ -196,7 +196,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
 
         #expect(characteristic == .email, "The value 0x01 is interpreted as “Email”")
     }
@@ -211,7 +211,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic == GATTSupportedUnreadAlertCategory(data: Data([0x03, 0x00])))
         #expect(characteristic.categories == [.email, .simpleAlert], "The value 0x03 is interpreted that this server supports “Simple Alert” and “Email” categories for unread alert.")
 
@@ -227,7 +227,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
 
         // The value 0x01, 0x04 are interpreted that the server has 4 unread messages in Email category.
         #expect(characteristic.category == .email)
@@ -244,7 +244,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
 
         // The data 0x02 0x01 interprets “Disable New Incoming Notification for Email Category”.
         #expect(characteristic.command == .disableNewIncomingAlertNotification)
@@ -287,7 +287,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic == 0)
         #expect(characteristic.rawValue == altitude)
         #expect(characteristic.description == "0")
@@ -311,7 +311,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.beats == beats)
         #expect(characteristic.description == "34")
         #expect(beats.description == "34")
@@ -335,7 +335,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.beats == beats)
         #expect(characteristic.description == "34")
         #expect(beats.description == "34")
@@ -353,7 +353,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic == .mild, "The value 0x01 should be interpreted as mild Alert")
         #expect(GATTAlertLevel.uuid == BluetoothUUID.Characteristic.alertLevel)
     }
@@ -374,7 +374,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.beats == beats)
         #expect(characteristic.description == "50")
         #expect(beats.description == "50")
@@ -398,7 +398,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.year == year)
         #expect(characteristic.description == "50")
         #expect(year.description == "50")
@@ -416,7 +416,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.states.contains(.ringer))
         #expect(characteristic.states.contains(.displayAlert))
         #expect(characteristic.states.contains(.vibrate))
@@ -442,7 +442,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.beats == beats)
         #expect(characteristic.description == "34")
         #expect(beats.description == "34")
@@ -468,7 +468,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.beats == beats)
         #expect(characteristic.description == "34")
         #expect(beats.description == "34")
@@ -491,7 +491,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(GATTBarometricPressureTrend(data: Data([0x01])) == GATTBarometricPressureTrend.continuouslyFalling)
         #expect(GATTBarometricPressureTrend.uuid == BluetoothUUID.Characteristic.barometricPressureTrend)
         #expect(GATTBarometricPressureTrend.unitType == .unitless)
@@ -510,7 +510,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.description == "1")
         #expect(characteristic == 1)
         #expect(GATTBootMouseInputReport.uuid == BluetoothUUID.Characteristic.bootMouseInputReport)
@@ -528,7 +528,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.description == "1")
         #expect(characteristic == 1)
         #expect(GATTBootKeyboardInputReport.uuid == BluetoothUUID.Characteristic.bootKeyboardInputReport)
@@ -546,7 +546,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.description == "1")
         #expect(characteristic == 1)
         #expect(GATTBootKeyboardOutputReport.uuid == BluetoothUUID.Characteristic.bootKeyboardOutputReport)
@@ -562,7 +562,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.presentState == .unknown)
         #expect(characteristic.dischargeState == .notSupported)
         #expect(characteristic.chargeState == .notCharging)
@@ -581,7 +581,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data, "Encoded data does not match expected encoded data")
+        roundTrip(characteristic, encodes: data)
 
         // enum values
         #expect(GATTBodySensorLocation(data: Data([0x00])) == .other, "The value 0x00 should be interpreted as Other")
@@ -618,7 +618,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data, "Encoded data does not match expected encoded data")
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic == true, "The value 0x01 should be interpreted as Supported")
         #expect(GATTCentralAddressResolution.uuid == BluetoothUUID.Characteristic.centralAddressResolution)
         #expect(GATTCentralAddressResolution(data: Data([0x00])) == false, "The value 0x00 should be interpreted as Not Supported")
@@ -732,7 +732,7 @@ import Bluetooth
         #expect(GATTBodyCompositionMeasurement(data: Data([0x00, 0x00])) == nil)
         #expect(GATTBodyCompositionMeasurement(data: Data([0x00, 0x00, 0x00])) == nil)
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
 
         #expect(GATTBodyCompositionMeasurement.uuid == BluetoothUUID.Characteristic.bodyCompositionMeasurement)
     }
@@ -747,7 +747,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.sessionRunTime == 0xe51f)
         #expect(characteristic.sessionRunTime.description == "58655")
         #expect(characteristic.description == "58655 41601")
@@ -770,7 +770,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == "bluetooth")
         #expect(characteristic.description == "bluetooth")
         #expect(GATTModelNumber.uuid == BluetoothUUID.Characteristic.modelNumberString)
@@ -787,7 +787,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == "bluetooth")
         #expect(characteristic.description == "bluetooth")
         #expect(GATTFirmwareRevisionString.uuid == BluetoothUUID.Characteristic.firmwareRevisionString)
@@ -804,7 +804,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == "bluetooth")
         #expect(characteristic.description == "bluetooth")
         #expect(GATTSoftwareRevisionString.uuid == BluetoothUUID.Characteristic.softwareRevisionString)
@@ -821,7 +821,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == "bluetooth")
         #expect(characteristic.description == "bluetooth")
         #expect(GATTHardwareRevisionString.uuid == BluetoothUUID.Characteristic.hardwareRevisionString)
@@ -838,7 +838,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == "bluetooth")
         #expect(characteristic.description == "bluetooth")
         #expect(GATTSerialNumberString.uuid == BluetoothUUID.Characteristic.serialNumberString)
@@ -855,7 +855,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == "bluetooth")
         #expect(characteristic.description == "bluetooth")
         #expect(GATTManufacturerNameString.uuid == BluetoothUUID.Characteristic.manufacturerNameString)
@@ -872,7 +872,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.vendorIdSource == .fromVendorIDValue)
         #expect(characteristic.description == "2 24321 24321 24321")
         #expect(GATTPnPID.uuid == BluetoothUUID.Characteristic.pnpId)
@@ -913,7 +913,7 @@ import Bluetooth
             #expect(characteristic.organizationallyUniqueIdentifier == organizationallyUniqueIdentifier)
             #expect(characteristic.description == "123456FFFE9ABCDE")
             #expect(characteristic.rawValue == 0x1234_56FF_FE9A_BCDE)
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic == GATTSystemID(data: data))
             #expect(characteristic == GATTSystemID(address: address))
         }
@@ -964,7 +964,7 @@ import Bluetooth
         }
 
         let configurations: BitMaskOptionSet<Configuration> = [.coordinates, .coordinateSystemUsed, .txPowerField, .altitudeField, .floorNumber, .locationName]
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.configurations == configurations, "The value 0x03 is interpreted as “Simple Alert and Email bits set")
         #expect(GATTIndoorPositioningConfiguration.uuid == BluetoothUUID.Characteristic.indoorPositioningConfiguration)
     }
@@ -981,7 +981,7 @@ import Bluetooth
         }
 
         #expect(characteristic == 234)
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == latitude)
         #expect(characteristic.description == "234")
         #expect(GATTLatitude.uuid == BluetoothUUID.Characteristic.latitude)
@@ -1000,7 +1000,7 @@ import Bluetooth
         }
 
         #expect(characteristic == 234)
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == longitude)
         #expect(characteristic.description == "234")
         #expect(GATTLongitude.uuid == BluetoothUUID.Characteristic.longitude)
@@ -1019,7 +1019,7 @@ import Bluetooth
         }
 
         #expect(characteristic == 234)
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == localNorthCoordinate)
         #expect(characteristic.description == "234")
         #expect(GATTLocalNorthCoordinate.uuid == BluetoothUUID.Characteristic.localNorthCoordinate)
@@ -1038,7 +1038,7 @@ import Bluetooth
         }
 
         #expect(characteristic == 234)
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == localEastCoordinate)
         #expect(characteristic.description == "234")
         #expect(GATTLocalEastCoordinate.uuid == BluetoothUUID.Characteristic.localEastCoordinate)
@@ -1056,7 +1056,7 @@ import Bluetooth
         }
 
         #expect(characteristic == 234)
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == data[0])
         #expect(characteristic.description == "234")
         #expect(GATTFloorNumber.uuid == BluetoothUUID.Characteristic.floorNumber)
@@ -1073,7 +1073,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.stationary == .mobile)
         #expect(characteristic.updateTime == .upTo3541s)
         #expect(characteristic.precision == .unknown)
@@ -1091,7 +1091,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.rawValue == "bluetooth")
         #expect(characteristic.description == "bluetooth")
         #expect(GATTLocationName.uuid == BluetoothUUID.Characteristic.locationName)
@@ -1108,7 +1108,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.day == .sunday)
         #expect(characteristic.description == "7")
         #expect(GATTDayOfWeek.uuid == BluetoothUUID.Characteristic.dayOfWeek)
@@ -1127,7 +1127,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.dateTime.data == Data([203, 7, 4, 24, 12, 5, 30]))
             #expect(characteristic.dayOfWeek == GATTDayOfWeek(day: .sunday))
             #expect(characteristic.dayOfWeek.day == .sunday)
@@ -1147,7 +1147,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.dayDateTime.data == Data([203, 7, 4, 24, 12, 5, 30, 7]))
             #expect(characteristic.fractions256 == 245)
             #expect(GATTExactTime256.uuid == BluetoothUUID.Characteristic.exactTime256)
@@ -1170,7 +1170,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.rawValue == 12)
             #expect(GATTTimeZone.uuid == BluetoothUUID.Characteristic.timeZone)
             #expect(GATTTimeZone(data: data) == GATTTimeZone(data: data))
@@ -1187,7 +1187,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic == .daylightTime)
         #expect(characteristic.description == "4")
         #expect(GATTDstOffset.uuid == BluetoothUUID.Characteristic.dstOffset)
@@ -1205,7 +1205,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.timeZone.data == Data([0x0c]))
             #expect(characteristic.dstOffset == .daylightTime)
             #expect(GATTLocalTimeInformation.uuid == BluetoothUUID.Characteristic.localTimeInformation)
@@ -1223,7 +1223,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic == .networkTimeProtocol)
         #expect(characteristic.description == "1")
         #expect(GATTTimeSource.uuid == BluetoothUUID.Characteristic.timeSource)
@@ -1241,7 +1241,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.rawValue == 12)
             #expect(characteristic.description == "12")
             #expect(characteristic == 12)
@@ -1264,7 +1264,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.timeSource == .radioTimeSignal)
             #expect(characteristic.timeAccuracy.rawValue == 0x0b)
             #expect(characteristic.daysSinceUpdate == 5)
@@ -1386,7 +1386,7 @@ import Bluetooth
                     remainingTime: 1285) == characteristic)
 
             #expect(characteristic.flags == BitMaskOptionSet<GATTCrossTrainerData.Flag>(rawValue: UInt32(bytes: (0b11111111, 0b01111111, 0x00, 0x00))))
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
         }
     }
 
@@ -1401,7 +1401,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
         }
 
         #expect(GATTTimeUpdateControlPoint(data: Data([1])) == .getReferenceUpdate)
@@ -1420,7 +1420,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.currentState == .idle)
         #expect(characteristic.result == .noConnectionToReference)
         #expect(GATTTimeUpdateState.uuid == BluetoothUUID.Characteristic.timeUpdateState)
@@ -1438,7 +1438,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.datetime == GATTDateTime(data: Data([203, 7, 4, 24, 12, 5, 30])))
             #expect(characteristic.dstOffset == GATTDstOffset(data: Data([8])))
             #expect(GATTTimeWithDst.uuid == BluetoothUUID.Characteristic.timeWithDst)
@@ -1455,7 +1455,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.exactTime == GATTExactTime256(data: Data([203, 7, 4, 24, 12, 5, 30, 7, 245])))
         #expect(characteristic.adjustReason == BitMaskOptionSet<GATTCurrentTime.Flag>(rawValue: 0b00001111))
         #expect(GATTCurrentTime.uuid == BluetoothUUID.Characteristic.currentTime)
@@ -1481,7 +1481,7 @@ import Bluetooth
                 return
             }
 
-            #expect(characteristic.data == data)
+            roundTrip(characteristic, encodes: data)
             #expect(characteristic.date == GATTDateUTC.Day(rawValue: 16_777_214))
             #expect(characteristic.description == "16777214")
             #expect(GATTDateUTC.uuid == BluetoothUUID.Characteristic.dateUtc)
@@ -1503,7 +1503,7 @@ import Bluetooth
         }
 
         #expect(GATTScanRefresh.uuid == BluetoothUUID.Characteristic.scanRefresh)
-        #expect(characteristic.data == data)
+        roundTrip(characteristic, encodes: data)
         #expect(characteristic.description == "0")
         #expect(characteristic == .serverRequiredRefresh)
     }
@@ -1518,7 +1518,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristics.data == data)
+        roundTrip(characteristics, encodes: data)
         #expect(characteristics.scanInterval == LowEnergyScanTimeInterval(rawValue: 16384))
         #expect(characteristics.scanWindow == LowEnergyScanTimeInterval(rawValue: 16384))
         #expect(GATTScanIntervalWindow.uuid == BluetoothUUID.Characteristic.scanIntervalWindow)
@@ -1535,7 +1535,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristics.data == data)
+        roundTrip(characteristics, encodes: data)
         #expect(characteristics.rawValue == 16384)
         #expect(characteristics.description == "4000")
         #expect(GATTObjectType.uuid == BluetoothUUID.Characteristic.objectType)
@@ -1554,7 +1554,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristics.data == data)
+        roundTrip(characteristics, encodes: data)
         #expect(characteristics.currentSize == Size(rawValue: 16394))
         #expect(characteristics.allocatedSize == Size(rawValue: 16394))
         #expect(GATTObjectSize.uuid == BluetoothUUID.Characteristic.objectSize)
@@ -1571,7 +1571,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristics.data == data)
+        roundTrip(characteristics, encodes: data)
         #expect(characteristics.rawValue == "bluetooth")
         #expect(characteristics.description == "bluetooth")
         #expect(GATTObjectName.uuid == BluetoothUUID.Characteristic.objectName)
@@ -1588,7 +1588,7 @@ import Bluetooth
             return
         }
 
-        #expect(characteristics.data == data)
+        roundTrip(characteristics, encodes: data)
         #expect(UInt64(characteristics.rawValue) == 281_474_976_710_655)
         #expect(characteristics.description == "281474976710655")
         #expect(GATTObjectID.uuid == BluetoothUUID.Characteristic.objectId)
@@ -1601,5 +1601,44 @@ internal extension GATTCharacteristic {
     var data: Data {
         Data(self)
     }
+}
+
+/// Round-trips a characteristic through the generic `DataConvertible` API
+/// across `Foundation.Data`, `[UInt8]` and `LowEnergyAdvertisingData`.
+internal func roundTrip<T: GATTCharacteristic>(
+    _ value: T,
+    encodes expected: Data,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let expectedBytes = [UInt8](expected)
+    #expect(value.dataLength == expectedBytes.count, sourceLocation: sourceLocation)
+    #expect(Data(value) == expected, sourceLocation: sourceLocation)
+    #expect([UInt8](value) == expectedBytes, sourceLocation: sourceLocation)
+    if expectedBytes.count <= LowEnergyAdvertisingData.capacity {
+        #expect(LowEnergyAdvertisingData(value) == LowEnergyAdvertisingData(expectedBytes), sourceLocation: sourceLocation)
+    }
+    // decode from a non-Foundation container and re-encode
+    if let decoded = T(data: expectedBytes) {
+        #expect([UInt8](decoded) == expectedBytes, sourceLocation: sourceLocation)
+    } else {
+        Issue.record("Could not decode \(T.self) from bytes", sourceLocation: sourceLocation)
+    }
+}
+
+internal func roundTrip<T: GATTCharacteristic & Equatable>(
+    _ value: T,
+    encodes expected: Data,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let expectedBytes = [UInt8](expected)
+    #expect(value.dataLength == expectedBytes.count, sourceLocation: sourceLocation)
+    #expect(Data(value) == expected, sourceLocation: sourceLocation)
+    #expect([UInt8](value) == expectedBytes, sourceLocation: sourceLocation)
+    if expectedBytes.count <= LowEnergyAdvertisingData.capacity {
+        #expect(LowEnergyAdvertisingData(value) == LowEnergyAdvertisingData(expectedBytes), sourceLocation: sourceLocation)
+        #expect(T(data: LowEnergyAdvertisingData(expectedBytes)) == value, sourceLocation: sourceLocation)
+    }
+    // decode from a non-Foundation container
+    #expect(T(data: expectedBytes) == value, sourceLocation: sourceLocation)
 }
 #endif


### PR DESCRIPTION
## What changed

Finishes the encode-side `DataContainer` migration for the GATT characteristic types (#161) and removes the deprecated `Foundation.Data` API surface.

- `GATTCharacteristic` now refines `DataConvertible`, matching `GATTDescriptor` and `GAPData`. All 66 conforming types implement the generic `append<Data: DataContainer>(to:)` and `dataLength` instead of hand-written `var data: Foundation.Data`.
- Removed `DeprecatedGATTCharacteristic` and the bridging defaults in `GATTCharacteristic.swift`. The old defaults (`var data` / `append`) were mutually recursive — a type implementing neither would infinitely recurse at runtime; that footgun is gone since `append` is now a hard requirement.
- Removed the module's own `DataContainer.init<T: GATTCharacteristic>` overload; the `DataConvertible` one in the core module adds `reserveCapacity` plus a debug `assert(count == dataLength)` that validates every hand-written `dataLength` in tests.
- Dropped `import Foundation` from migrated files (kept where genuinely needed: `GATTDateTime`, `GATTAlertNotificationControlPoint`, `GATTUUIDList`).
- Renamed `GATTBloodPressureManagement.swift` → `GATTBloodPressureMeasurement.swift` to match the type it declares.

### Bugs fixed in passing

- `GATTCrossTrainerData` never declared the `GATTCharacteristic` conformance — it only had the members. Added.
- `GATTCrossTrainerData` counted 1 byte for `expendedEnergy` where the encoder writes 5 (`Bits16 × 2 + Byte`); harmless as `reserveCapacity`, wrong as `dataLength`. Fixed.
- `GATTBloodPressureMeasurement` encoded mean arterial pressure without `.littleEndian`, unlike its sibling fields (big-endian-platform bug). Normalized.
- `GATTNewAlert.Information` no longer has a `fatalError` path on string encoding (`data += rawValue.utf8`).

### Tests

Replaced the 65 Foundation-only `#expect(characteristic.data == data)` assertions with a `roundTrip` helper that checks `dataLength` and round-trips each characteristic through `Foundation.Data`, `[UInt8]`, and `LowEnergyAdvertisingData`, so the generic path is actually exercised.

## Reviewer notes

- **Source-breaking:** downstream code loses `characteristic.data` — use `Data(characteristic)` instead.
- **Byte-order review point:** all multibyte appends go through `.littleEndian`; CI hosts are little-endian so a missed one wouldn't fail tests.
- All 279 tests pass in debug (with the `dataLength` asserts active) and release; `swift format lint` / `swiftlint` clean on touched files.