### PR TITLE
Migrate HCICommandParameter encoding to DataContainer

### DIFF
--- a/Sources/BluetoothHCI/HCIAcceptConnectionRequest.swift
+++ b/Sources/BluetoothHCI/HCIAcceptConnectionRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 public extension BluetoothHostControllerInterface {
 
     /// Accept Connection Command
@@ -57,11 +55,11 @@ public struct HCIAcceptConnectionRequest: HCICommandParameter {
         self.role = role
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
@@ -69,7 +67,7 @@ public struct HCIAcceptConnectionRequest: HCICommandParameter {
             addressBytes.4,
             addressBytes.5,
             role.rawValue
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIAuthenticationComplete.swift
+++ b/Sources/BluetoothHCI/HCIAuthenticationComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Authentication Complete Event
 ///
 /// The Authentication Complete event occurs when authentication has been completed for the specified connection. The Connection_Handle must be a Connection_Handle for an ACL connection.

--- a/Sources/BluetoothHCI/HCIAuthenticationRequested.swift
+++ b/Sources/BluetoothHCI/HCIAuthenticationRequested.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -51,10 +49,10 @@ public struct HCIAuthenticationRequested: HCICommandParameter {
         self.handle = handle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1])
+        data += [handleBytes.0, handleBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCIChangeConnectionPacketType.swift
+++ b/Sources/BluetoothHCI/HCIChangeConnectionPacketType.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -56,12 +54,12 @@ public struct HCIChangeConnectionPacketType: HCICommandParameter {
         self.packetType = packetType
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
         let packetTypeBytes = packetType.rawValue.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1, packetTypeBytes.0, packetTypeBytes.1])
+        data += [handleBytes.0, handleBytes.1, packetTypeBytes.0, packetTypeBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCICommand.swift
+++ b/Sources/BluetoothHCI/HCICommand.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// HCI Command.
 public protocol HCICommand: RawRepresentable, Hashable, CustomStringConvertible {
 
@@ -49,8 +47,17 @@ public protocol HCICommandParameter {
 
     static var command: Command { get }
 
-    /// Converts command parameter to raw bytes.
-    var data: Data { get }
+    /// Append the command parameter bytes into the buffer.
+    func append<Data: DataContainer>(to data: inout Data)
+}
+
+public extension DataContainer {
+
+    /// Initialize data with contents of command parameter.
+    init<T: HCICommandParameter>(_ value: T) {
+        self.init()
+        value.append(to: &self)
+    }
 }
 
 /// The return value (not event) returned by an HCI command.

--- a/Sources/BluetoothHCI/HCICommandComplete.swift
+++ b/Sources/BluetoothHCI/HCICommandComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// HCI Command Complete
 @frozen
 public struct HCICommandComplete: HCIEventParameter {

--- a/Sources/BluetoothHCI/HCICommandStatus.swift
+++ b/Sources/BluetoothHCI/HCICommandStatus.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// HCI Command Status Event
 @frozen
 public struct HCICommandStatus: HCIEventParameter {

--- a/Sources/BluetoothHCI/HCIConnectionComplete.swift
+++ b/Sources/BluetoothHCI/HCIConnectionComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Connection Complete Event
 ///
 /// The Connection Complete event indicates to both of the Hosts forming the connection that a new connection has been established. This event also indicates to the Host, which issued the Create_Connection, or Accept_Connection_ Request or Reject_Connection_Request command and then received a Command Status event, if the issued command failed or was successful.

--- a/Sources/BluetoothHCI/HCIConnectionPacketTypeChange.swift
+++ b/Sources/BluetoothHCI/HCIConnectionPacketTypeChange.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The Connection Packet Type Changed event is used to indicate that the process has completed of the Link Manager changing which packet types can be used for the connection. This allows current connections to be dynamically modified to support different types of user data. The Packet_Type event parameter specifies which packet types the Link Manager can use for the connection identified by the Connection_Handle event parameter for sending L2CAP data or voice. The Packet_Type event parameter does not decide which packet types the LM is allowed to use for sending LMP PDUs.
 @frozen
 public struct HCIConnectionPacketTypeChange: HCIEventParameter {

--- a/Sources/BluetoothHCI/HCIConnectionRequest.swift
+++ b/Sources/BluetoothHCI/HCIConnectionRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Connection Request Event
 ///
 /// The Connection Request event is used to indicate that a new incoming connection is trying to be established. The connection may either be accepted or rejected. If this event is masked away and there is an incoming connection attempt and the BR/EDR Controller is not set to auto-accept this connection attempt, the BR/EDR Controller shall automatically refuse the connection attempt. When the Host receives this event and the link type parameter is ACL, it should respond with either an Accept_Connection_Request or Reject_Connection_Request command before the timer Conn_Accept_Timeout expires. If the link type is SCO or eSCO, the Host should reply with the Accept_Synchronous_Connection_Request or the Reject_Synchronous_Connection_Request command. If the link type is SCO, the Host may respond with Accept_Connection_Request command. If the event is responded to with Accept_Connection_Request command, then the default parameter settings of the Accept_Synchronous_Connection_Request command (see Section 7.1.27 on page 504) should be used by the local Link Manager when negotiating the SCO link parameters. In that case, the Connection Complete event and not the Synchronous Connection Complete event, shall be returned on completion of the connection.

--- a/Sources/BluetoothHCI/HCICreateConnection.swift
+++ b/Sources/BluetoothHCI/HCICreateConnection.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -82,7 +80,7 @@ public struct HCICreateConnection: HCICommandParameter {
         self.allowRoleSwitch = allowRoleSwitch
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
@@ -90,14 +88,14 @@ public struct HCICreateConnection: HCICommandParameter {
 
         let clockOffsetBytes = clockOffset.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0, addressBytes.1, addressBytes.2, addressBytes.3, addressBytes.4, addressBytes.5,  // address
             packetTypeBytes.0, packetTypeBytes.1,  // packet type
             pageScanRepetitionMode.rawValue,  // page scan repetition mode
             reserved.rawValue,  // reserved
             clockOffsetBytes.0, clockOffsetBytes.1,  // clock offset
             allowRoleSwitch.rawValue
-        ])  // allow role switch
+        ]  // allow role switch
     }
 }
 

--- a/Sources/BluetoothHCI/HCICreateConnectionCancel.swift
+++ b/Sources/BluetoothHCI/HCICreateConnectionCancel.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -44,11 +42,11 @@ public struct HCICreateConnectionCancel: HCICommandParameter {
         self.address = address
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([addressBytes.0, addressBytes.1, addressBytes.2, addressBytes.3, addressBytes.4, addressBytes.5])
+        data += [addressBytes.0, addressBytes.1, addressBytes.2, addressBytes.3, addressBytes.4, addressBytes.5]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIDeleteStoredLinkKey.swift
+++ b/Sources/BluetoothHCI/HCIDeleteStoredLinkKey.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -49,11 +47,11 @@ public struct HCIDeleteStoredLinkKey: HCICommandParameter {
         self.deleteFlag = deleteFlag
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
@@ -61,7 +59,7 @@ public struct HCIDeleteStoredLinkKey: HCICommandParameter {
             addressBytes.4,
             addressBytes.5,
             deleteFlag.rawValue
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIDisconnect.swift
+++ b/Sources/BluetoothHCI/HCIDisconnect.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -53,11 +51,11 @@ public struct HCIDisconnect: HCICommandParameter {
         self.error = error
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionBytes = connectionHandle.littleEndian.bytes
 
-        return Data([connectionBytes.0, connectionBytes.1, error.rawValue])
+        data += [connectionBytes.0, connectionBytes.1, error.rawValue]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIDisconnectionComplete.swift
+++ b/Sources/BluetoothHCI/HCIDisconnectionComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Disconnection Complete Event
 ///
 /// The Disconnection Complete event occurs when a connection is terminated. The status parameter indicates if the disconnection was successful or not. The reason parameter indicates the reason for the disconnection if the disconnection was successful. If the disconnection was not successful, the value of the reason parameter can be ignored by the Host. For example, this can be the case if the Host has issued the Disconnect command and there was a parameter error, or the command was not presently allowed, or a Connection_Handle that didn’t correspond to a connection was given.

--- a/Sources/BluetoothHCI/HCIEncryptionChange.swift
+++ b/Sources/BluetoothHCI/HCIEncryptionChange.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Encryption Change Event
 ///
 /// The Encryption Change event is used to indicate that the change of the encryption mode has been completed.

--- a/Sources/BluetoothHCI/HCIEncryptionKeyRefreshComplete.swift
+++ b/Sources/BluetoothHCI/HCIEncryptionKeyRefreshComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Encryption Key Refresh Complete Event
 ///
 /// The Encryption Key Refresh Complete event is used to indicate to the Host that the encryption key was

--- a/Sources/BluetoothHCI/HCIError.swift
+++ b/Sources/BluetoothHCI/HCIError.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 PureSwift. All rights reserved.
 //
 
+import Foundation
+
 /// Bluetooth HCI Errors
 ///
 /// If an HCI Command that should generate a Command Complete event generates an error
@@ -536,8 +538,6 @@ extension HCIError: CustomStringConvertible {
 // MARK: - CustomNSError
 
 #if canImport(Darwin)
-
-import Foundation
 
 extension HCIError: CustomNSError {
 

--- a/Sources/BluetoothHCI/HCIEvent.swift
+++ b/Sources/BluetoothHCI/HCIEvent.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// HCI Event Opcode
 public protocol HCIEvent: RawRepresentable, Hashable, CustomStringConvertible {
 

--- a/Sources/BluetoothHCI/HCIExitPeriodicInquiryMode.swift
+++ b/Sources/BluetoothHCI/HCIExitPeriodicInquiryMode.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIHoldMode.swift
+++ b/Sources/BluetoothHCI/HCIHoldMode.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Hold Mode Command
 ///
 /// The Hold_Mode command is used to alter the behavior of the Link Manager, and have it place the ACL baseband connection associated by the specified Connection_Handle into the hold mode. The Hold_Mode_Max_Interval and Hold_Mode_Min_Interval command parameters specify the length of time the Host wants to put the connection into the hold mode. The local and remote devices will negotiate the length in the hold mode. The Hold_Mode_Max_ Interval parameter is used to specify the maximum length of the Hold interval for which the Host may actually enter into the hold mode after negotiation with the remote device. The Hold interval defines the amount of time between when the Hold Mode begins and when the Hold Mode is completed. The Hold_ Mode_Min_Interval parameter is used to specify the minimum length of the Hold interval for which the Host may actually enter into the hold mode after the negotiation with the remote device. Therefore the Hold_Mode_Min_Interval cannot be greater than the Hold_Mode_Max_Interval. The BR/EDR Controller will return the actual Hold interval in the Interval parameter of the Mode Change event, if the command is successful. This command enables the Host to support a low-power policy for itself or several other BR/EDR Controllers, and allows the devices to enter Inquiry Scan, Page Scan, and a number of other possible actions.
@@ -37,7 +35,7 @@ public struct HCIHoldMode: HCICommandParameter {
         self.interval = interval
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         // Connection_Handle
         let handleBytes = connectionHandle.littleEndian.bytes
@@ -48,14 +46,14 @@ public struct HCIHoldMode: HCICommandParameter {
         // Hold_Mode_Min_Interval
         let intervalMinBytes = interval.rawValue.lowerBound.littleEndian.bytes
 
-        return Data([
+        data += [
             handleBytes.0,
             handleBytes.1,
             intervalMaxBytes.0,
             intervalMaxBytes.1,
             intervalMinBytes.0,
             intervalMinBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIIOCapabilityRequest.swift
+++ b/Sources/BluetoothHCI/HCIIOCapabilityRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The IO Capability Request event is used to indicate that the IO capabilities of the Host are required for a simple pairing process. The Host shall respond with an IO_Capability_Request_Reply command. This event shall only be generated if simple pairing has been enabled with the Write_Simple_Pairing_Mode command.
 @frozen
 public struct HCIIOCapabilityRequest: HCIEventParameter {

--- a/Sources/BluetoothHCI/HCIIOCapabilityRequestReply.swift
+++ b/Sources/BluetoothHCI/HCIIOCapabilityRequestReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -71,11 +69,11 @@ public struct HCIIOCapabilityRequestReply: HCICommandParameter {
         self.authenticationRequirements = authenticationRequirements
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
@@ -85,7 +83,7 @@ public struct HCIIOCapabilityRequestReply: HCICommandParameter {
             ioCapability.rawValue,
             oobDataPresent.rawValue,
             authenticationRequirements.rawValue
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIIOCapabilityResponse.swift
+++ b/Sources/BluetoothHCI/HCIIOCapabilityResponse.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The IO Capability Response event is used to indicate to the host that IO capa- bilities from a remote device specified by BD_ADDR have been received dur- ing a simple pairing process. This event will only be generated if simple pairing has been enabled with the Write_Simple_Pairing_Mode command.
 @frozen
 public struct HCIIOCapabilityResponse: HCIEventParameter {

--- a/Sources/BluetoothHCI/HCIInquiry.swift
+++ b/Sources/BluetoothHCI/HCIInquiry.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -37,7 +35,6 @@ public extension BluetoothHostControllerInterface {
         var isComplete = false
 
         try pollEvent(HCInquiryComplete.self, shouldContinue: shouldContinue) { (complete) in
-
 
         }*/
     }
@@ -77,11 +74,11 @@ public struct HCIInquiry: HCICommandParameter {
         self.responses = responses
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let lapBytes = lap.rawValue.littleEndian.bytes
 
-        return Data([lapBytes.0, lapBytes.1, lapBytes.2, duration.rawValue, responses.rawValue])
+        data += [lapBytes.0, lapBytes.1, lapBytes.2, duration.rawValue, responses.rawValue]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIInquiryCancel.swift
+++ b/Sources/BluetoothHCI/HCIInquiryCancel.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIInquiryComplete.swift
+++ b/Sources/BluetoothHCI/HCIInquiryComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Inquiry Complete Event
 ///
 /// The Inquiry Complete event indicates that the Inquiry is finished. This event contains a Status parameter, which is used to indicate if the Inquiry completed successfully or if the Inquiry was not completed.

--- a/Sources/BluetoothHCI/HCIInquiryResult.swift
+++ b/Sources/BluetoothHCI/HCIInquiryResult.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Inquiry Result Event
 ///
 /// The Inquiry Result event indicates that a BR/EDR Controller or multiple BR/ EDR Controllers have responded so far during the current Inquiry process. This event will be sent from the BR/EDR Controller to the Host as soon as an Inquiry Response from a remote device is received if the remote device supports only mandatory paging scheme. The BR/EDR Controller may queue these Inquiry Responses and send multiple BR/EDR Controllers information in one Inquiry Result event. The event can be used to return one or more Inquiry responses in one event.

--- a/Sources/BluetoothHCI/HCILEAddDeviceToPeriodicAdvertiserList.swift
+++ b/Sources/BluetoothHCI/HCILEAddDeviceToPeriodicAdvertiserList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -63,11 +61,11 @@ public struct HCILEAddDeviceToPeriodicAdvertiserList: HCICommandParameter {
         self.advertisingSid = advertisingSid
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([
+        data += [
             advertiserAddressType.rawValue,
             addressBytes.0,
             addressBytes.1,
@@ -76,6 +74,6 @@ public struct HCILEAddDeviceToPeriodicAdvertiserList: HCICommandParameter {
             addressBytes.4,
             addressBytes.5,
             advertisingSid
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILEAddDeviceToResolvingList.swift
+++ b/Sources/BluetoothHCI/HCILEAddDeviceToResolvingList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -67,13 +65,13 @@ public struct HCILEAddDeviceToResolvingList: HCICommandParameter {
         self.localIrk = localIrk
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let peerIdentifyAddressBytes = peerIdentifyAddress.littleEndian.bytes
         let peerIrkBytes = peerIrk.littleEndian.bytes
         let localIrkBytes = localIrk.littleEndian.bytes
 
-        return Data([
+        data += [
             peerIdentifyAddressType.rawValue,
             peerIdentifyAddressBytes.0,
             peerIdentifyAddressBytes.1,
@@ -115,6 +113,6 @@ public struct HCILEAddDeviceToResolvingList: HCICommandParameter {
             localIrkBytes.13,
             localIrkBytes.14,
             localIrkBytes.15
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILEAddDeviceToWhiteList.swift
+++ b/Sources/BluetoothHCI/HCILEAddDeviceToWhiteList.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
 import Bluetooth
 
 // MARK: - Method
@@ -84,7 +83,4 @@ extension HCILEAddDeviceToWhiteList: DataConvertible {
         Self.length
     }
 
-    public var data: Data {
-        return Data(self)
-    }
 }

--- a/Sources/BluetoothHCI/HCILEAdvertisingReport.swift
+++ b/Sources/BluetoothHCI/HCILEAdvertisingReport.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Advertising Report Event
 ///
 /// The LE Advertising Report event indicates that a Bluetooth device

--- a/Sources/BluetoothHCI/HCILEAdvertisingSetTerminated.swift
+++ b/Sources/BluetoothHCI/HCILEAdvertisingSetTerminated.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Advertising Set Terminated Event
 ///
 /// The event indicates that the Controller has terminated advertising in the advertising sets specified by the Advertising_Handle parameter.

--- a/Sources/BluetoothHCI/HCILEChannelSelectionAlgorithm.swift
+++ b/Sources/BluetoothHCI/HCILEChannelSelectionAlgorithm.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Channel Selection Algorithm Event
 ///
 /// The LE Channel Selection Algorithm Event indicates which channel selection algorithm is used on a data channel connection.

--- a/Sources/BluetoothHCI/HCILEConnectionComplete.swift
+++ b/Sources/BluetoothHCI/HCILEConnectionComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Connection Complete Event
 ///
 /// The LE Connection Complete event indicates to both of the Hosts forming the connection

--- a/Sources/BluetoothHCI/HCILEConnectionUpdateComplete.swift
+++ b/Sources/BluetoothHCI/HCILEConnectionUpdateComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Connection Update Complete Event
 ///
 /// The event is used to indicate that the Controller process to update the connection has completed.

--- a/Sources/BluetoothHCI/HCILECreateConnection.swift
+++ b/Sources/BluetoothHCI/HCILECreateConnection.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -157,11 +155,8 @@ extension HCILECreateConnection {
 
     static var length: Int { return 2 + 2 + 1 + 1 + 6 + 1 + 2 + 2 + 2 + 2 + 2 + 2 }
 
-    public var data: Data {
-        var data = Data()
-        data.reserveCapacity(Self.length)
+    public func append<Data: DataContainer>(to data: inout Data) {
         data += self
-        return data
     }
 
     var dataLength: Int {

--- a/Sources/BluetoothHCI/HCILEDataLengthChange.swift
+++ b/Sources/BluetoothHCI/HCILEDataLengthChange.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Data Length Change Event
 ///
 /// event notifies the Host of a change to either the maximum Payload length or the maximum transmission time of packets

--- a/Sources/BluetoothHCI/HCILEDirectedAdvertisingReport.swift
+++ b/Sources/BluetoothHCI/HCILEDirectedAdvertisingReport.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Directed Advertising Report Event
 ///
 /// The event indicates that directed advertisements have been received where the advertiser

--- a/Sources/BluetoothHCI/HCILEEncrypt.swift
+++ b/Sources/BluetoothHCI/HCILEEncrypt.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -60,11 +58,8 @@ public struct HCILEEncrypt: HCICommandParameter {  // HCI_LE_Encrypt
 
 extension HCILEEncrypt {
 
-    public var data: Data {
-        var data = Data()
-        data.reserveCapacity(self.dataLength)
+    public func append<Data: DataContainer>(to data: inout Data) {
         data += self
-        return data
     }
 
     var dataLength: Int { return 32 }

--- a/Sources/BluetoothHCI/HCILEEnhancedConnectionComplete.swift
+++ b/Sources/BluetoothHCI/HCILEEnhancedConnectionComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Enhanced Connection Complete Event
 ///
 /// The event indicates to both of the Hosts forming the connection that a new connection has been created.

--- a/Sources/BluetoothHCI/HCILEEnhancedReceiverTest.swift
+++ b/Sources/BluetoothHCI/HCILEEnhancedReceiverTest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -46,8 +44,8 @@ public struct HCILEEnhancedReceiverTest: HCICommandParameter {
         self.modulationIndex = modulationIndex
     }
 
-    public var data: Data {
-        return Data([rxChannel.rawValue, phy.rawValue, modulationIndex.rawValue])
+    public func append<Data: DataContainer>(to data: inout Data) {
+        data += [rxChannel.rawValue, phy.rawValue, modulationIndex.rawValue]
     }
 
     public enum Phy: UInt8 {

--- a/Sources/BluetoothHCI/HCILEEnhancedTransmitterTest.swift
+++ b/Sources/BluetoothHCI/HCILEEnhancedTransmitterTest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -64,9 +62,9 @@ public struct HCILEEnhancedTransmitterTest: HCICommandParameter {
         self.phy = phy
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([txChannel.rawValue, lengthOfTestData, packetPayload.rawValue, phy.rawValue])
+        data += [txChannel.rawValue, lengthOfTestData, packetPayload.rawValue, phy.rawValue]
     }
 
     public enum Phy: UInt8 {

--- a/Sources/BluetoothHCI/HCILEExtendedCreateConnection.swift
+++ b/Sources/BluetoothHCI/HCILEExtendedCreateConnection.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -78,11 +76,11 @@ public struct HCILEExtendedCreateConnection: HCICommandParameter {
         self.initialingPHY = initialingPHY
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = peerAddress.littleEndian.bytes
 
-        return Data([
+        data += [
             initialingFilterPolicy.rawValue,
             ownAddressType.rawValue,
             peerAddressType.rawValue,
@@ -92,7 +90,7 @@ public struct HCILEExtendedCreateConnection: HCICommandParameter {
             addressBytes.3,
             addressBytes.4,
             addressBytes.5
-        ])
+        ]
     }
 
     public enum InitialingFilterPolicy: UInt8 {  // Initiating_Filter_Policy

--- a/Sources/BluetoothHCI/HCILEGenerateDHKey.swift
+++ b/Sources/BluetoothHCI/HCILEGenerateDHKey.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -47,11 +45,11 @@ public struct HCILEGenerateDHKey: HCICommandParameter {
         self.remoteP256PublicKey = remoteP256PublicKey
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let remoteP256PublicKeyBytes = remoteP256PublicKey.littleEndian.bytes
 
-        return Data([
+        data += [
             remoteP256PublicKeyBytes.0,
             remoteP256PublicKeyBytes.1,
             remoteP256PublicKeyBytes.2,
@@ -117,6 +115,6 @@ public struct HCILEGenerateDHKey: HCICommandParameter {
             remoteP256PublicKeyBytes.61,
             remoteP256PublicKeyBytes.62,
             remoteP256PublicKeyBytes.63
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILEGenerateDHKeyComplete.swift
+++ b/Sources/BluetoothHCI/HCILEGenerateDHKeyComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Generate DHKey Complete Event
 ///
 /// This event indicates that LE Diffie Hellman key generation has been completed by the Controller.

--- a/Sources/BluetoothHCI/HCILELongTermKeyRequest.swift
+++ b/Sources/BluetoothHCI/HCILELongTermKeyRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Long Term Key Request Event
 ///
 /// The LE Long Term Key Request event indicates that the master device is attempting

--- a/Sources/BluetoothHCI/HCILELongTermKeyRequestNegativeReply.swift
+++ b/Sources/BluetoothHCI/HCILELongTermKeyRequestNegativeReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -45,14 +43,14 @@ public struct HCILELongTermKeyRequestNegativeReply: HCICommandParameter {
         self.connectionHandle = connectionHandle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILELongTermKeyRequestReply.swift
+++ b/Sources/BluetoothHCI/HCILELongTermKeyRequestReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -50,12 +48,12 @@ public struct HCILELongTermKeyRequestReply: HCICommandParameter {
         self.longTermKey = longTermKey
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
         let longTermKeyBytes = longTermKey.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1,
             longTermKeyBytes.0,
@@ -74,7 +72,7 @@ public struct HCILELongTermKeyRequestReply: HCICommandParameter {
             longTermKeyBytes.13,
             longTermKeyBytes.14,
             longTermKeyBytes.15
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingCreateSync.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingCreateSync.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -72,13 +70,13 @@ public struct HCILEPeriodicAdvertisingCreateSync: HCICommandParameter {
         self.unused = unused
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
         let skipBytes = skip.littleEndian.bytes
         let syncTimeoutBytes = syncTimeout.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             filterPolicy.rawValue,
             advertisingSid,
             advertisingAddressType.rawValue,
@@ -93,7 +91,7 @@ public struct HCILEPeriodicAdvertisingCreateSync: HCICommandParameter {
             syncTimeoutBytes.0,
             syncTimeoutBytes.1,
             unused
-        ])
+        ]
     }
 
     public struct SyncTimeout: RawRepresentable, Equatable, Hashable, Comparable, Sendable {

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncEstablished.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncEstablished.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Periodic Advertising Sync Established Event
 ///
 /// The event indicates that the Controller has received the first periodic advertising packet from an advertiser

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncLost.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncLost.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Periodic Advertising Sync Lost Event
 ///
 /// The event indicates that the Controller has not received a Periodic Advertising packet identified

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingTerminateSync.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingTerminateSync.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -48,9 +46,9 @@ public struct HCILEPeriodicAdvertisingTerminateSync: HCICommandParameter {
         self.syncHandle = syncHandle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
         let syncHandleBytes = syncHandle.littleEndian.bytes
 
-        return Data([syncHandleBytes.0, syncHandleBytes.1])
+        data += [syncHandleBytes.0, syncHandleBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCILEPhyUpdateComplete.swift
+++ b/Sources/BluetoothHCI/HCILEPhyUpdateComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE PHY Update Complete Event
 ///
 /// The LE PHY Update Complete Event is used to indicate that the Controller has changed

--- a/Sources/BluetoothHCI/HCILERandom.swift
+++ b/Sources/BluetoothHCI/HCILERandom.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadAdvertisingChannelTxPower.swift
+++ b/Sources/BluetoothHCI/HCILEReadAdvertisingChannelTxPower.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadBufferSize.swift
+++ b/Sources/BluetoothHCI/HCILEReadBufferSize.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadChannelMap.swift
+++ b/Sources/BluetoothHCI/HCILEReadChannelMap.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -46,14 +44,14 @@ public struct HCILEReadChannelMap: HCICommandParameter {  // HCI_LE_Read_Channel
         self.connectionHandle = connectionHandle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILEReadLocalP256PublicKeyComplete.swift
+++ b/Sources/BluetoothHCI/HCILEReadLocalP256PublicKeyComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Read Local P-256 Public Key Complete Event
 ///
 /// This event is generated when local P-256 key generation is complete.

--- a/Sources/BluetoothHCI/HCILEReadLocalResolvableAddressReturn.swift
+++ b/Sources/BluetoothHCI/HCILEReadLocalResolvableAddressReturn.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -62,11 +60,11 @@ public struct HCILEReadLocalResolvableAddress: HCICommandParameter {  //HCI_LE_R
         self.peerIdentifyAddress = peerIdentifyAddress
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let peerIdentifyAddressBytes = peerIdentifyAddress.littleEndian.bytes
 
-        return Data([
+        data += [
             peerIdentifyAddressType.rawValue,
             peerIdentifyAddressBytes.0,
             peerIdentifyAddressBytes.1,
@@ -76,7 +74,7 @@ public struct HCILEReadLocalResolvableAddress: HCICommandParameter {  //HCI_LE_R
             peerIdentifyAddressBytes.5,
             peerIdentifyAddressBytes.6,
             peerIdentifyAddressBytes.7
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILEReadLocalSupportedFeatures.swift
+++ b/Sources/BluetoothHCI/HCILEReadLocalSupportedFeatures.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadMaximumAdvertisingDataLength.swift
+++ b/Sources/BluetoothHCI/HCILEReadMaximumAdvertisingDataLength.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadMaximumDataLength.swift
+++ b/Sources/BluetoothHCI/HCILEReadMaximumDataLength.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadNumberOfSupportedAdvertisingSets.swift
+++ b/Sources/BluetoothHCI/HCILEReadNumberOfSupportedAdvertisingSets.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadPeerResolvableAddressReturn.swift
+++ b/Sources/BluetoothHCI/HCILEReadPeerResolvableAddressReturn.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -58,11 +56,11 @@ public struct HCILEReadPeerResolvableAddress: HCICommandParameter {  //HCI_LE_Re
         self.peerIdentifyAddress = peerIdentifyAddress
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let peerIdentifyAddressBytes = peerIdentifyAddress.littleEndian.bytes
 
-        return Data([
+        data += [
             peerIdentifyAddressType.rawValue,
             peerIdentifyAddressBytes.0,
             peerIdentifyAddressBytes.1,
@@ -72,7 +70,7 @@ public struct HCILEReadPeerResolvableAddress: HCICommandParameter {  //HCI_LE_Re
             peerIdentifyAddressBytes.5,
             peerIdentifyAddressBytes.6,
             peerIdentifyAddressBytes.7
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILEReadPeriodicAdvertisingListSize.swift
+++ b/Sources/BluetoothHCI/HCILEReadPeriodicAdvertisingListSize.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadPhy.swift
+++ b/Sources/BluetoothHCI/HCILEReadPhy.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -45,14 +43,14 @@ public struct HCILEReadPHY: HCICommandParameter {
         self.connectionHandle = connectionHandle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILEReadRemoteUsedFeatures.swift
+++ b/Sources/BluetoothHCI/HCILEReadRemoteUsedFeatures.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -61,13 +59,13 @@ public struct HCILEReadRemoteUsedFeatures: HCICommandParameter {  //HCI_LE_Read_
         self.connectionHandle = connectionHandle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILEReadRemoteUsedFeaturesComplete.swift
+++ b/Sources/BluetoothHCI/HCILEReadRemoteUsedFeaturesComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Read Remote Features Complete Event
 ///
 /// The event is used to indicate the completion of the process of the Controller

--- a/Sources/BluetoothHCI/HCILEReadResolvingListSize.swift
+++ b/Sources/BluetoothHCI/HCILEReadResolvingListSize.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadRfPathCompensation.swift
+++ b/Sources/BluetoothHCI/HCILEReadRfPathCompensation.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadSuggestedDefaultDataLength.swift
+++ b/Sources/BluetoothHCI/HCILEReadSuggestedDefaultDataLength.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadSupportedStates.swift
+++ b/Sources/BluetoothHCI/HCILEReadSupportedStates.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadTransmitPower.swift
+++ b/Sources/BluetoothHCI/HCILEReadTransmitPower.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReadWhiteListSize.swift
+++ b/Sources/BluetoothHCI/HCILEReadWhiteListSize.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILEReceiverTest.swift
+++ b/Sources/BluetoothHCI/HCILEReceiverTest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -44,8 +42,8 @@ public struct HCILEReceiverTest: HCICommandParameter {
         self.rxChannel = rxChannel
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([rxChannel.rawValue])
+        data += [rxChannel.rawValue]
     }
 }

--- a/Sources/BluetoothHCI/HCILERemoteConnectionParameterRequest.swift
+++ b/Sources/BluetoothHCI/HCILERemoteConnectionParameterRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Remote Connection Parameter Request Event
 ///
 /// This event indicates to the master’s Host or the slave’s Host that the remote device is requesting

--- a/Sources/BluetoothHCI/HCILERemoteConnectionParameterRequestNegativeReply.swift
+++ b/Sources/BluetoothHCI/HCILERemoteConnectionParameterRequestNegativeReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -60,15 +58,15 @@ public struct HCILERemoteConnectionParameterRequestNegativeReply: HCICommandPara
         self.reason = reason
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1,
             reason
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILERemoteConnectionParameterRequestReply.swift
+++ b/Sources/BluetoothHCI/HCILERemoteConnectionParameterRequestReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -76,7 +74,7 @@ public struct HCILERemoteConnectionParameterRequestReply: HCICommandParameter {
         self.length = length
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
         let connectionIntervalMinBytes = interval.rawValue.lowerBound.littleEndian.bytes
@@ -86,7 +84,7 @@ public struct HCILERemoteConnectionParameterRequestReply: HCICommandParameter {
         let connectionLengthMinBytes = length.rawValue.lowerBound.littleEndian.bytes
         let connectionLengthMaxBytes = length.rawValue.upperBound.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1,
             connectionIntervalMinBytes.0,
@@ -101,7 +99,7 @@ public struct HCILERemoteConnectionParameterRequestReply: HCICommandParameter {
             connectionLengthMinBytes.1,
             connectionLengthMaxBytes.0,
             connectionLengthMaxBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILERemoveAdvertisingSet.swift
+++ b/Sources/BluetoothHCI/HCILERemoveAdvertisingSet.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -45,7 +43,7 @@ public struct HCILERemoveAdvertisingSet: HCICommandParameter {
         self.advertisingHandle = advertisingHandle
     }
 
-    public var data: Data {
-        return Data([advertisingHandle])
+    public func append<Data: DataContainer>(to data: inout Data) {
+        data += [advertisingHandle]
     }
 }

--- a/Sources/BluetoothHCI/HCILERemoveDeviceFromResolvingList.swift
+++ b/Sources/BluetoothHCI/HCILERemoveDeviceFromResolvingList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -67,11 +65,11 @@ public struct HCILERemoveDeviceFromResolvingList: HCICommandParameter {
         self.peerIdentifyAddress = peerIdentifyAddress
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let peerIdentifyAddressBytes = peerIdentifyAddress.littleEndian.bytes
 
-        return Data([
+        data += [
             peerIdentifyAddressType.rawValue,
             peerIdentifyAddressBytes.0,
             peerIdentifyAddressBytes.1,
@@ -81,6 +79,6 @@ public struct HCILERemoveDeviceFromResolvingList: HCICommandParameter {
             peerIdentifyAddressBytes.5,
             peerIdentifyAddressBytes.6,
             peerIdentifyAddressBytes.7
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILERemoveDeviceFromWhiteList.swift
+++ b/Sources/BluetoothHCI/HCILERemoveDeviceFromWhiteList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -51,11 +49,8 @@ public struct HCILERemoveDeviceFromWhiteList: HCICommandParameter {  // HCI_LE_R
 
 extension HCILERemoveDeviceFromWhiteList {
 
-    public var data: Data {
-        var data = Data()
-        data.reserveCapacity(self.dataLength)
+    public func append<Data: DataContainer>(to data: inout Data) {
         data += self
-        return data
     }
 
     var dataLength: Int {

--- a/Sources/BluetoothHCI/HCILERemoveDeviceToPeriodicAdvertiserList.swift
+++ b/Sources/BluetoothHCI/HCILERemoveDeviceToPeriodicAdvertiserList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -69,11 +67,8 @@ public struct HCILERemoveDeviceToPeriodicAdvertiserList: HCICommandParameter {
 
 extension HCILERemoveDeviceToPeriodicAdvertiserList {
 
-    public var data: Data {
-        var data = Data()
-        data.reserveCapacity(self.dataLength)
+    public func append<Data: DataContainer>(to data: inout Data) {
         data += self
-        return data
     }
 
     var dataLength: Int { return 1 + BluetoothAddress.length + 1 }

--- a/Sources/BluetoothHCI/HCILEScanRequestReceived.swift
+++ b/Sources/BluetoothHCI/HCILEScanRequestReceived.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Scan Request Received Event
 ///
 /// The vent indicates that a SCAN_REQ PDU or an AUX_SCAN_REQ PDU has been received by the advertiser.

--- a/Sources/BluetoothHCI/HCILESetAddressResolutionEnable.swift
+++ b/Sources/BluetoothHCI/HCILESetAddressResolutionEnable.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -50,8 +48,8 @@ public struct HCILESetAddressResolutionEnable: HCICommandParameter {  //HCI_LE_S
         self.addressResolutionEnable = addressResolutionEnable
     }
 
-    public var data: Data {
-        return Data([addressResolutionEnable.rawValue])
+    public func append<Data: DataContainer>(to data: inout Data) {
+        data += [addressResolutionEnable.rawValue]
     }
 
     public enum AddressResolutionEnable: UInt8 {

--- a/Sources/BluetoothHCI/HCILESetAdvertiseEnable.swift
+++ b/Sources/BluetoothHCI/HCILESetAdvertiseEnable.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -54,8 +52,8 @@ public struct HCILESetAdvertiseEnable: HCICommandParameter {  // HCI_LE_Set_Adve
         self.isEnabled = isEnabled
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([isEnabled.byteValue])
+        data += [isEnabled.byteValue]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetAdvertisingData.swift
+++ b/Sources/BluetoothHCI/HCILESetAdvertisingData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -47,8 +45,8 @@ public struct HCILESetAdvertisingData: HCICommandParameter {  // HCI_LE_Set_Adve
         self.advertisingData = advertisingData
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([advertisingData.length, advertisingData.bytes.0, advertisingData.bytes.1, advertisingData.bytes.2, advertisingData.bytes.3, advertisingData.bytes.4, advertisingData.bytes.5, advertisingData.bytes.6, advertisingData.bytes.7, advertisingData.bytes.8, advertisingData.bytes.9, advertisingData.bytes.10, advertisingData.bytes.11, advertisingData.bytes.12, advertisingData.bytes.13, advertisingData.bytes.14, advertisingData.bytes.15, advertisingData.bytes.16, advertisingData.bytes.17, advertisingData.bytes.18, advertisingData.bytes.19, advertisingData.bytes.20, advertisingData.bytes.21, advertisingData.bytes.22, advertisingData.bytes.23, advertisingData.bytes.24, advertisingData.bytes.25, advertisingData.bytes.26, advertisingData.bytes.27, advertisingData.bytes.28, advertisingData.bytes.29, advertisingData.bytes.30])
+        data += [advertisingData.length, advertisingData.bytes.0, advertisingData.bytes.1, advertisingData.bytes.2, advertisingData.bytes.3, advertisingData.bytes.4, advertisingData.bytes.5, advertisingData.bytes.6, advertisingData.bytes.7, advertisingData.bytes.8, advertisingData.bytes.9, advertisingData.bytes.10, advertisingData.bytes.11, advertisingData.bytes.12, advertisingData.bytes.13, advertisingData.bytes.14, advertisingData.bytes.15, advertisingData.bytes.16, advertisingData.bytes.17, advertisingData.bytes.18, advertisingData.bytes.19, advertisingData.bytes.20, advertisingData.bytes.21, advertisingData.bytes.22, advertisingData.bytes.23, advertisingData.bytes.24, advertisingData.bytes.25, advertisingData.bytes.26, advertisingData.bytes.27, advertisingData.bytes.28, advertisingData.bytes.29, advertisingData.bytes.30]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetAdvertisingParameters.swift
+++ b/Sources/BluetoothHCI/HCILESetAdvertisingParameters.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -93,11 +91,8 @@ extension HCILESetAdvertisingParameters {
 
     static var length: Int { return 2 + 2 + 1 + 1 + 1 + 6 + 1 + 1 }
 
-    public var data: Data {
-        var data = Data()
-        data.reserveCapacity(Self.length)
+    public func append<Data: DataContainer>(to data: inout Data) {
         data += self
-        return data
     }
 
     var dataLength: Int {

--- a/Sources/BluetoothHCI/HCILESetAdvertisingSetRandomAddress.swift
+++ b/Sources/BluetoothHCI/HCILESetAdvertisingSetRandomAddress.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -57,11 +55,11 @@ public struct HCILESetAdvertisingSetRandomAddress: HCICommandParameter {  //HCI_
         self.advertisingRandomAddress = advertisingRandomAddress
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let advertisingRandomAddressBytes = advertisingRandomAddress.littleEndian.bytes
 
-        return Data([
+        data += [
             advertisingHandle,
             advertisingRandomAddressBytes.0,
             advertisingRandomAddressBytes.1,
@@ -69,6 +67,6 @@ public struct HCILESetAdvertisingSetRandomAddress: HCICommandParameter {  //HCI_
             advertisingRandomAddressBytes.3,
             advertisingRandomAddressBytes.4,
             advertisingRandomAddressBytes.5
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetDataLength.swift
+++ b/Sources/BluetoothHCI/HCILESetDataLength.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -62,20 +60,20 @@ public struct HCILESetDataLength: HCICommandParameter {
         self.txTime = txTime
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
         let txOctetsBytes = txOctets.rawValue.littleEndian.bytes
         let txTimeBytes = txTime.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1,
             txOctetsBytes.0,
             txOctetsBytes.1,
             txTimeBytes.0,
             txTimeBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILESetDefaultPhy.swift
+++ b/Sources/BluetoothHCI/HCILESetDefaultPhy.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -56,7 +54,7 @@ public struct HCILESetDefaultPhy: HCICommandParameter {
         self.rxPhys = rxPhys
     }
 
-    public var data: Data {
-        return Data([allPhys.rawValue, txPhys.rawValue, rxPhys.rawValue])
+    public func append<Data: DataContainer>(to data: inout Data) {
+        data += [allPhys.rawValue, txPhys.rawValue, rxPhys.rawValue]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetEventMask.swift
+++ b/Sources/BluetoothHCI/HCILESetEventMask.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - BluetoothHostControllerInterface
 
 public extension BluetoothHostControllerInterface {
@@ -55,11 +53,11 @@ public struct HCILESetEventMask: HCICommandParameter {
         self.eventMask = eventMask
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let eventMaskBytes = eventMask.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             eventMaskBytes.0,
             eventMaskBytes.1,
             eventMaskBytes.2,
@@ -68,7 +66,7 @@ public struct HCILESetEventMask: HCICommandParameter {
             eventMaskBytes.5,
             eventMaskBytes.6,
             eventMaskBytes.7
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILESetExtendedAdvertisingData.swift
+++ b/Sources/BluetoothHCI/HCILESetExtendedAdvertisingData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -57,16 +55,17 @@ public struct HCILESetExtendedAdvertisingData: HCICommandParameter {
         self.advertisingData = advertisingData
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let advertisingDataLength = UInt8(advertisingData.count)
 
-        return Data([
+        data += [
             advertisingHandle,
             operation.rawValue,
             fragmentPreference.rawValue,
             advertisingDataLength
-        ]) + advertisingData
+        ]
+        data += advertisingData
     }
 
     public enum Operation: UInt8 {  //Operation

--- a/Sources/BluetoothHCI/HCILESetExtendedAdvertisingParameters.swift
+++ b/Sources/BluetoothHCI/HCILESetExtendedAdvertisingParameters.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -121,7 +119,7 @@ public struct HCILESetExtendedAdvertisingParameters: HCICommandParameter {  //HC
         self.scanRequestNotificationEnable = scanRequestNotificationEnable
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let advertisingEventPropertiesBytes = advertisingEventProperties.rawValue.littleEndian.bytes
 
@@ -132,7 +130,7 @@ public struct HCILESetExtendedAdvertisingParameters: HCICommandParameter {  //HC
 
         let advertisingTxPowerByte = UInt8.init(bitPattern: advertisingTxPower.rawValue)
 
-        return Data([
+        data += [
             advertisingHandle,
             advertisingEventPropertiesBytes.0,
             advertisingEventPropertiesBytes.1,
@@ -158,7 +156,7 @@ public struct HCILESetExtendedAdvertisingParameters: HCICommandParameter {  //HC
             secondaryAdvertisingPhy.rawValue,
             advertisingSid,
             scanRequestNotificationEnable.rawValue
-        ])
+        ]
     }
 
     /// The Scan_Request_Notification_Enable parameter indicates whether the Controller shall send

--- a/Sources/BluetoothHCI/HCILESetExtendedScanEnable.swift
+++ b/Sources/BluetoothHCI/HCILESetExtendedScanEnable.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -61,19 +59,19 @@ public struct HCILESetExtendedScanEnable: HCICommandParameter {
         self.period = period
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let durationBytes = duration.rawValue.littleEndian.bytes
         let periodBytes = period.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             enable.rawValue,
             filterDuplicates.rawValue,
             durationBytes.0,
             durationBytes.1,
             periodBytes.0,
             periodBytes.1
-        ])
+        ]
     }
 
     /// The Enable parameter determines whether scanning is enabled or disabled.

--- a/Sources/BluetoothHCI/HCILESetExtendedScanParameters.swift
+++ b/Sources/BluetoothHCI/HCILESetExtendedScanParameters.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -55,7 +53,7 @@ public struct HCILESetExtendedScanParameters: HCICommandParameter {
         self.scanningPHY = scanningPHY
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let length: Int
 
@@ -69,8 +67,6 @@ public struct HCILESetExtendedScanParameters: HCICommandParameter {
 
             length = 3 + 10
         }
-
-        var data = Data()
         data.reserveCapacity(length)  // improve buffer performance
 
         // Own_Address_Type
@@ -107,8 +103,6 @@ public struct HCILESetExtendedScanParameters: HCICommandParameter {
         }
 
         assert(data.count == length, "Invalid number of bytes")
-
-        return data
     }
 
     public enum ScanningFilterPolicy: UInt8 {

--- a/Sources/BluetoothHCI/HCILESetExtendedScanResponseData.swift
+++ b/Sources/BluetoothHCI/HCILESetExtendedScanResponseData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -58,14 +56,15 @@ public struct HCILESetExtendedScanResponseData: HCICommandParameter {
         self.scanResponseData = scanResponseData
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let scanResponseDataLength = UInt8(scanResponseData.count)
 
-        return Data([
+        data += [
             advertisingHandle, operation.rawValue,
             fragmentPreference.rawValue, scanResponseDataLength
-        ]) + scanResponseData
+        ]
+        data += scanResponseData
     }
 
     public enum Operation: UInt8 {  //Operation

--- a/Sources/BluetoothHCI/HCILESetHostChannelClassification.swift
+++ b/Sources/BluetoothHCI/HCILESetHostChannelClassification.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Command
 
 /// LE Set Host Channel Classification Command
@@ -31,13 +29,13 @@ public struct HCILESetHostChannelClassification: HCICommandParameter {  // HCI_L
         self.channelMap = channelMap
     }
 
-    public var data: Data {
-        return Data([
+    public func append<Data: DataContainer>(to data: inout Data) {
+        data += [
             channelMap.0,
             channelMap.1,
             channelMap.2,
             channelMap.3,
             channelMap.4
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingData.swift
+++ b/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -53,15 +51,16 @@ public struct HCILESetPeriodicAdvertisingData: HCICommandParameter {
         self.advertisingData = advertisingData
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let advertisingDataLength = UInt8(advertisingData.count)
 
-        return Data([
+        data += [
             advertisingHandle,
             operation.rawValue,
             advertisingDataLength
-        ]) + advertisingData
+        ]
+        data += advertisingData
     }
 
     public enum Operation: UInt8 {  //Operation

--- a/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingEnable.swift
+++ b/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingEnable.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -47,11 +45,11 @@ public struct HCILESetPeriodicAdvertisingEnable: HCICommandParameter {
         self.advertisingHandle = advertisingHandle
     }
 
-    public var data: Data {
-        return Data([
+    public func append<Data: DataContainer>(to data: inout Data) {
+        data += [
             enable.rawValue,
             advertisingHandle
-        ])
+        ]
     }
 
     public enum Enable: UInt8 {

--- a/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingParameters.swift
+++ b/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingParameters.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -76,12 +74,12 @@ public struct HCILESetPeriodicAdvertisingParameters: HCICommandParameter {
         self.advertisingEventProperties = advertisingEventProperties
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let periodicAdvertisingIntervalMinBytes = periodicAdvertisingInterval.rawValue.lowerBound.littleEndian.bytes
         let periodicAdvertisingIntervalMaxBytes = periodicAdvertisingInterval.rawValue.upperBound.littleEndian.bytes
         let advertisingEventPropertiesytes = advertisingEventProperties.rawValue.littleEndian.bytes
-        return Data([
+        data += [
             advertisingHandle,
             periodicAdvertisingIntervalMinBytes.0,
             periodicAdvertisingIntervalMinBytes.1,
@@ -89,7 +87,7 @@ public struct HCILESetPeriodicAdvertisingParameters: HCICommandParameter {
             periodicAdvertisingIntervalMaxBytes.1,
             advertisingEventPropertiesytes.0,
             advertisingEventPropertiesytes.1
-        ])
+        ]
     }
 
     public struct PeriodicAdvertisingInterval: RawRepresentable, Equatable, Hashable, Sendable {

--- a/Sources/BluetoothHCI/HCILESetPhy.swift
+++ b/Sources/BluetoothHCI/HCILESetPhy.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -84,12 +82,12 @@ public struct HCILESetPhy: HCICommandParameter {
         self.phyOptions = phyOptions
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let connectionHandleBytes = connectionHandle.littleEndian.bytes
         let phyOptionsBytes = phyOptions.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandleBytes.0,
             connectionHandleBytes.1,
             allPhys.rawValue,
@@ -97,6 +95,6 @@ public struct HCILESetPhy: HCICommandParameter {
             rxPhys.rawValue,
             phyOptionsBytes.0,
             phyOptionsBytes.1
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetPrivacyMode.swift
+++ b/Sources/BluetoothHCI/HCILESetPrivacyMode.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -56,11 +54,11 @@ public struct HCILESetPrivacyMode: HCICommandParameter {
         self.privacyMode = privacyMode
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = peerIdentityAddress.littleEndian.bytes
 
-        return Data([
+        data += [
             peerIdentityAddressType.rawValue,
             addressBytes.0,
             addressBytes.1,
@@ -69,7 +67,7 @@ public struct HCILESetPrivacyMode: HCICommandParameter {
             addressBytes.4,
             addressBytes.5,
             privacyMode.rawValue
-        ])
+        ]
     }
 
     public enum PrivacyMode: UInt8 {

--- a/Sources/BluetoothHCI/HCILESetRandomAddress.swift
+++ b/Sources/BluetoothHCI/HCILESetRandomAddress.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -49,10 +47,10 @@ public struct HCILESetRandomAddress: HCICommandParameter {
         self.address = address
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let bytes = address.littleEndian.bytes
 
-        return Data([bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5])
+        data += [bytes.0, bytes.1, bytes.2, bytes.3, bytes.4, bytes.5]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetResolvablePrivateAddressTimeout.swift
+++ b/Sources/BluetoothHCI/HCILESetResolvablePrivateAddressTimeout.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -49,14 +47,14 @@ public struct HCILESetResolvablePrivateAddressTimeout: HCICommandParameter {
         self.rpaTimeout = rpaTimeout
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let rpaTimeoutBytes = rpaTimeout.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             rpaTimeoutBytes.0,
             rpaTimeoutBytes.1
-        ])
+        ]
     }
 
     /// RPA_Timeout measured in s

--- a/Sources/BluetoothHCI/HCILESetScanEnable.swift
+++ b/Sources/BluetoothHCI/HCILESetScanEnable.swift
@@ -142,8 +142,8 @@ public struct HCILESetScanEnable: HCICommandParameter {  // HCI_LE_Set_Scan_Enab
         self.filterDuplicates = filterDuplicates
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([isEnabled.byteValue, filterDuplicates.byteValue])
+        data += [isEnabled.byteValue, filterDuplicates.byteValue]
     }
 }

--- a/Sources/BluetoothHCI/HCILESetScanParameters.swift
+++ b/Sources/BluetoothHCI/HCILESetScanParameters.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// LE Set Scan Parameters Command
 ///
 /// Used to set the scan parameters.
@@ -55,7 +53,7 @@ public struct HCILESetScanParameters: HCICommandParameter {  // HCI_LE_Set_Scan_
         self.filterPolicy = filterPolicy
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let scanType = type.rawValue
         let scanInterval = interval.rawValue.littleEndian.bytes
@@ -63,7 +61,7 @@ public struct HCILESetScanParameters: HCICommandParameter {  // HCI_LE_Set_Scan_
         let ownAddressType = addressType.rawValue
         let filter = filterPolicy.rawValue
 
-        return Data([scanType, scanInterval.0, scanInterval.1, scanWindow.0, scanWindow.1, ownAddressType, filter])
+        data += [scanType, scanInterval.0, scanInterval.1, scanWindow.0, scanWindow.1, ownAddressType, filter]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILESetScanResponseData.swift
+++ b/Sources/BluetoothHCI/HCILESetScanResponseData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -53,8 +51,8 @@ public struct HCILESetScanResponseData: HCICommandParameter {  // HCI_LE_Set_Sca
         self.advertisingData = advertisingData
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([advertisingData.length, advertisingData.bytes.0, advertisingData.bytes.1, advertisingData.bytes.2, advertisingData.bytes.3, advertisingData.bytes.4, advertisingData.bytes.5, advertisingData.bytes.6, advertisingData.bytes.7, advertisingData.bytes.8, advertisingData.bytes.9, advertisingData.bytes.10, advertisingData.bytes.11, advertisingData.bytes.12, advertisingData.bytes.13, advertisingData.bytes.14, advertisingData.bytes.15, advertisingData.bytes.16, advertisingData.bytes.17, advertisingData.bytes.18, advertisingData.bytes.19, advertisingData.bytes.20, advertisingData.bytes.21, advertisingData.bytes.22, advertisingData.bytes.23, advertisingData.bytes.24, advertisingData.bytes.25, advertisingData.bytes.26, advertisingData.bytes.27, advertisingData.bytes.28, advertisingData.bytes.29, advertisingData.bytes.30])
+        data += [advertisingData.length, advertisingData.bytes.0, advertisingData.bytes.1, advertisingData.bytes.2, advertisingData.bytes.3, advertisingData.bytes.4, advertisingData.bytes.5, advertisingData.bytes.6, advertisingData.bytes.7, advertisingData.bytes.8, advertisingData.bytes.9, advertisingData.bytes.10, advertisingData.bytes.11, advertisingData.bytes.12, advertisingData.bytes.13, advertisingData.bytes.14, advertisingData.bytes.15, advertisingData.bytes.16, advertisingData.bytes.17, advertisingData.bytes.18, advertisingData.bytes.19, advertisingData.bytes.20, advertisingData.bytes.21, advertisingData.bytes.22, advertisingData.bytes.23, advertisingData.bytes.24, advertisingData.bytes.25, advertisingData.bytes.26, advertisingData.bytes.27, advertisingData.bytes.28, advertisingData.bytes.29, advertisingData.bytes.30]
     }
 }

--- a/Sources/BluetoothHCI/HCILEStartEncryption.swift
+++ b/Sources/BluetoothHCI/HCILEStartEncryption.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -142,11 +140,8 @@ public struct HCILEStartEncryption: HCICommandParameter {  // HCI_LE_Start_Encry
 
 extension HCILEStartEncryption {
 
-    public var data: Data {
-        var data = Data()
-        data.reserveCapacity(self.dataLength)
+    public func append<Data: DataContainer>(to data: inout Data) {
         data += self
-        return data
     }
 
     var dataLength: Int {

--- a/Sources/BluetoothHCI/HCILETestEnd.swift
+++ b/Sources/BluetoothHCI/HCILETestEnd.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCILETransmitterTest.swift
+++ b/Sources/BluetoothHCI/HCILETransmitterTest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -63,8 +61,8 @@ public struct HCILETransmitterTest: HCICommandParameter {
         self.packetPayload = packetPayload
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([txChannel.rawValue, packetPayload.rawValue])
+        data += [txChannel.rawValue, packetPayload.rawValue]
     }
 }

--- a/Sources/BluetoothHCI/HCILEUpdateConnection.swift
+++ b/Sources/BluetoothHCI/HCILEUpdateConnection.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -105,7 +103,7 @@ public struct HCILEUpdateConnection: HCICommandParameter {  // HCI_LE_Connection
         self.connectionLength = connectionLength
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
         let connectionIntervalMinBytes = connectionInterval.rawValue.lowerBound.littleEndian.bytes
         let connectionIntervalMaxBytes = connectionInterval.rawValue.upperBound.littleEndian.bytes
         let connectionLatencyBytes = connectionLatency.rawValue.littleEndian.bytes
@@ -113,7 +111,7 @@ public struct HCILEUpdateConnection: HCICommandParameter {  // HCI_LE_Connection
         let connectionLengthMinBytes = connectionLength.rawValue.lowerBound.littleEndian.bytes
         let connectionLengthMaxBytes = connectionLength.rawValue.upperBound.littleEndian.bytes
 
-        return Data([
+        data += [
             connectionHandle.littleEndian.bytes.0,
             connectionHandle.littleEndian.bytes.1,
             connectionIntervalMinBytes.0,
@@ -128,6 +126,6 @@ public struct HCILEUpdateConnection: HCICommandParameter {  // HCI_LE_Connection
             connectionLengthMinBytes.1,
             connectionLengthMaxBytes.0,
             connectionLengthMaxBytes.1
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILEWriteRfPathCompensation.swift
+++ b/Sources/BluetoothHCI/HCILEWriteRfPathCompensation.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -63,16 +61,16 @@ public struct HCILEWriteRfPathCompensation: HCICommandParameter {
         self.rfRxPathCompensationValue = rfRxPathCompensationValue
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
         let rfTxPathCompensationValueBytes = UInt16.init(bitPattern: rfTxPathCompensationValue.rawValue).littleEndian.bytes
 
         let rfRxPathCompensationValueBytes = UInt16.init(bitPattern: rfRxPathCompensationValue.rawValue).littleEndian.bytes
 
-        return Data([
+        data += [
             rfTxPathCompensationValueBytes.0,
             rfTxPathCompensationValueBytes.1,
             rfRxPathCompensationValueBytes.0,
             rfRxPathCompensationValueBytes.1
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILEWriteSuggestedDefaultDataLength.swift
+++ b/Sources/BluetoothHCI/HCILEWriteSuggestedDefaultDataLength.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -53,15 +51,15 @@ public struct HCILEWriteSuggestedDefaultDataLength: HCICommandParameter {
         self.suggestedMaxTxTime = suggestedMaxTxTime
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
         let suggestedMaxTxOctetsBytes = suggestedMaxTxOctets.rawValue.littleEndian.bytes
         let suggestedMaxTxTimeBytes = suggestedMaxTxTime.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             suggestedMaxTxOctetsBytes.0,
             suggestedMaxTxOctetsBytes.1,
             suggestedMaxTxTimeBytes.0,
             suggestedMaxTxTimeBytes.1
-        ])
+        ]
     }
 }

--- a/Sources/BluetoothHCI/HCILinkKeyNotification.swift
+++ b/Sources/BluetoothHCI/HCILinkKeyNotification.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Link Key Notification Event
 ///
 /// The Link Key Notification event is used to indicate to the Host that a new Link Key has been created for the connection with the device specified in BD_ADDR. The Host can save this new Link Key in its own storage for future use. Also, the Host can decided to store the Link Key in the BR/EDR Control- ler’s Link Key Storage by using the Write_Stored_Link_Key command. The Key_Type event parameter informs the Host about which key type (combina- tion key, local unit key, or remote unit key, debug combination key, unauthenti- cated combination key, authenticated combination key or changed combination key) that was used during pairing. If pairing with unit key is not supported, the Host can for instance discard the key or disconnect the link.

--- a/Sources/BluetoothHCI/HCILinkKeyRequest.swift
+++ b/Sources/BluetoothHCI/HCILinkKeyRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Link Key Request Event
 ///
 /// The Link Key Request event is used to indicate that a Link Key is required for the connection with the device specified in BD_ADDR. If the Host has the requested stored Link Key, then the Host shall pass the requested Key to the Controller using the Link_Key_Request_Reply command. If the Host does not have the requested stored Link Key, or the stored Link Key does not meet the security requirements for the requested service, then the Host shall use the Link_Key_Request_Negative_Reply command to indicate to the Controller that the Host does not have the requested key.

--- a/Sources/BluetoothHCI/HCILinkKeyRequestNegativeReply.swift
+++ b/Sources/BluetoothHCI/HCILinkKeyRequestNegativeReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -44,18 +42,18 @@ public struct HCILinkKeyRequestNegativeReply: HCICommandParameter {
         self.address = address
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
             addressBytes.3,
             addressBytes.4,
             addressBytes.5
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCILinkKeyRequestReply.swift
+++ b/Sources/BluetoothHCI/HCILinkKeyRequestReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -51,13 +49,13 @@ public struct HCILinkKeyRequestReply: HCICommandParameter {
         self.linkKey = linkKey
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
         let linkKeyBytes = linkKey.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
@@ -80,7 +78,7 @@ public struct HCILinkKeyRequestReply: HCICommandParameter {
             linkKeyBytes.13,
             linkKeyBytes.14,
             linkKeyBytes.15
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIMaxSlotsChange.swift
+++ b/Sources/BluetoothHCI/HCIMaxSlotsChange.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Max Slots Change Event
 ///
 /// This event is used to notify the Host about the LMP_Max_Slots parameter when the value of this parameter changes. It shall be sent each time the maximum allowed length, in number of slots, for baseband packets transmitted by the local device, changes. The Connection_Handle will be a Connection_Handle for an ACL connection.

--- a/Sources/BluetoothHCI/HCIModeChange.swift
+++ b/Sources/BluetoothHCI/HCIModeChange.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Mode Change Event
 ///
 /// The Mode Change event is used to indicate when the device associated with the Connection_Handle changes between Active mode, Hold mode, and Sniff mode, and Park state. The Connection_Handle will be a Connection_Handle for an ACL connection. The Connection_Handle event parameter is used to indicate which connection the Mode Change event is for. The Current_Mode event parameter is used to indicate which state the connection is currently in. The Interval parameter is used to specify a time amount specific to each state. Each Controller that is associated with the Connection_Handle which has changed Modes shall send the Mode Change event to its Host.

--- a/Sources/BluetoothHCI/HCINumberOfCompletedPackets.swift
+++ b/Sources/BluetoothHCI/HCINumberOfCompletedPackets.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The Number Of Completed Packets event is used by the Controller to indicate to the Host how many HCI Data Packets have been completed (transmitted or flushed) for each Connection_Handle since the previous Number Of Completed Packets event was sent to the Host. This means that the corresponding buffer space has been freed in the Controller. Based on this information, and the HC_Total_Num_ACL_Data_Packets and HC_Total_Num_Synchronous_Data_Packets return parameter of the Read_Buffer_Size command, the Host can determine for which Connection_Handles the following HCI Data Packets should be sent to the Controller. The Number Of Completed Packets event must not be sent before the corresponding Connection Complete event. While the Controller has HCI data packets in its buffer, it must keep sending the Number Of Completed Packets event to the Host at least periodically, until it finally reports that all the pending ACL Data Packets have been transmitted or flushed. The rate with which this event is sent is manufacturer specific.
 ///
 /// - Note: Number Of Completed Packets events will not report on synchronous Connection Handles if synchronous Flow Control is disabled.

--- a/Sources/BluetoothHCI/HCIPINCodeRequest.swift
+++ b/Sources/BluetoothHCI/HCIPINCodeRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The PIN Code Request event is used to indicate that a PIN code is required to create a new link key. The Host shall respond using either the PIN_Code_Request_Reply or the PIN_Code_Request_Negative_Reply command, depending on whether the Host can provide the Controller with a PIN code or not.
 ///
 /// - Note: If the PIN Code Request event is masked away, then the BR/EDR Controller will assume that the Host has no PIN Code.

--- a/Sources/BluetoothHCI/HCIPINCodeRequestReply.swift
+++ b/Sources/BluetoothHCI/HCIPINCodeRequestReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -62,13 +60,13 @@ public struct HCIPINCodeRequestReply: HCICommandParameter {
         self.pinCode = pinCode
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
         let pinCodeBytes = pinCode.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
@@ -92,7 +90,7 @@ public struct HCIPINCodeRequestReply: HCICommandParameter {
             pinCodeBytes.13,
             pinCodeBytes.14,
             pinCodeBytes.15
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIPacketHeader.swift
+++ b/Sources/BluetoothHCI/HCIPacketHeader.swift
@@ -16,7 +16,18 @@ public protocol HCIPacketHeader {
 
     init?<Data: DataContainer>(data: Data)
 
-    var data: Data { get }
+    /// Append the header bytes into the buffer.
+    func append<Data: DataContainer>(to data: inout Data)
+}
+
+public extension DataContainer {
+
+    /// Initialize data with contents of packet header.
+    init<T: HCIPacketHeader>(_ value: T) {
+        self.init()
+        self.reserveCapacity(T.length)
+        value.append(to: &self)
+    }
 }
 
 // MARK: - Command Header
@@ -50,7 +61,7 @@ public struct HCICommandHeader: HCIPacketHeader {  // hci_command_hdr (packed)
     public static func from<T: HCICommandParameter>(_ commandParameter: T) -> (HCICommandHeader, Data) {
 
         let command = type(of: commandParameter).command
-        let parameterData = commandParameter.data
+        let parameterData = Data(commandParameter)
 
         let header = HCICommandHeader(
             command: command,
@@ -68,11 +79,11 @@ public struct HCICommandHeader: HCIPacketHeader {  // hci_command_hdr (packed)
         self.parameterLength = data[2]
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let opcodeBytes = opcode.littleEndian.bytes
 
-        return Data([opcodeBytes.0, opcodeBytes.1, parameterLength])
+        data += [opcodeBytes.0, opcodeBytes.1, parameterLength]
     }
 }
 
@@ -108,8 +119,8 @@ public struct HCIEventHeader: HCIPacketHeader {
         self.parameterLength = data[1]
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([event.rawValue, parameterLength])
+        data += [event.rawValue, parameterLength]
     }
 }

--- a/Sources/BluetoothHCI/HCIPageScanRepetitionMode.swift
+++ b/Sources/BluetoothHCI/HCIPageScanRepetitionMode.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The Page_Scan_Repetition_Mode parameter specifies the page scan repetition mode supported by the remote device with the BD_ADDR. This is the information that was acquired during the inquiry process.
 @frozen
 public struct PageScanRepetitionMode: RawRepresentable {

--- a/Sources/BluetoothHCI/HCIPeriodicInquiryMode.swift
+++ b/Sources/BluetoothHCI/HCIPeriodicInquiryMode.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -90,7 +88,7 @@ public struct HCIPeriodicInquiryMode: HCICommandParameter {
         self.responses = responses
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let minDurationBytes = minDuration.rawValue.littleEndian.bytes
 
@@ -98,13 +96,13 @@ public struct HCIPeriodicInquiryMode: HCICommandParameter {
 
         let lapBytes = lap.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             maxDurationBytes.0, maxDurationBytes.1,
             minDurationBytes.0, minDurationBytes.1,
             lapBytes.0, lapBytes.1, lapBytes.2,
             length.rawValue,
             responses.rawValue
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIQoSSetup.swift
+++ b/Sources/BluetoothHCI/HCIQoSSetup.swift
@@ -7,8 +7,6 @@
 //
 // swiftlint:disable function_parameter_count
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -85,7 +83,7 @@ public struct HCIQoSSetup: HCICommandParameter {
         self.delayVariation = delayVariation
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = connectionHandle.littleEndian.bytes
 
@@ -97,7 +95,7 @@ public struct HCIQoSSetup: HCICommandParameter {
 
         let delayVariationBytes = delayVariation.littleEndian.bytes
 
-        return Data([
+        data += [
             handleBytes.0,
             handleBytes.1,
             flags,
@@ -118,7 +116,7 @@ public struct HCIQoSSetup: HCICommandParameter {
             delayVariationBytes.1,
             delayVariationBytes.2,
             delayVariationBytes.3
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIQoSSetupComplete.swift
+++ b/Sources/BluetoothHCI/HCIQoSSetupComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// QoS Setup Complete Event
 ///
 /// The QoS Setup Complete event is used to indicate the completion of the process of the Link Manager setting up QoS with the remote BR/EDR Control- ler specified by the Connection_Handle event parameter. The Connection_Handle will be a Connection_Handle for an ACL connection.

--- a/Sources/BluetoothHCI/HCIReadClassOfDevice.swift
+++ b/Sources/BluetoothHCI/HCIReadClassOfDevice.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIReadClockOffset.swift
+++ b/Sources/BluetoothHCI/HCIReadClockOffset.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -48,10 +46,10 @@ public struct HCIReadClockOffset: HCICommandParameter {
         self.handle = handle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1])
+        data += [handleBytes.0, handleBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCIReadClockOffsetComplete.swift
+++ b/Sources/BluetoothHCI/HCIReadClockOffsetComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Read Clock Offset Complete Event
 ///
 /// The Read Clock Offset Complete event is used to indicate the completion of the process of the Link Manager obtaining the Clock Offset information of the BR/EDR Controller specified by the Connection_Handle event parameter. The Connection_Handle will be a Connection_Handle for an ACL connection.

--- a/Sources/BluetoothHCI/HCIReadConnectionAcceptTimeout.swift
+++ b/Sources/BluetoothHCI/HCIReadConnectionAcceptTimeout.swift
@@ -8,8 +8,6 @@
 
 // MARK: - Command
 
-import Foundation
-
 /// Read Connection Accept Timeout Command
 ///
 /// This command reads the value for the Connection Accept Timeout configuration parameter.

--- a/Sources/BluetoothHCI/HCIReadDataBlockSize.swift
+++ b/Sources/BluetoothHCI/HCIReadDataBlockSize.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIReadDeviceAddress.swift
+++ b/Sources/BluetoothHCI/HCIReadDeviceAddress.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIReadLMPHandle.swift
+++ b/Sources/BluetoothHCI/HCIReadLMPHandle.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -49,11 +47,11 @@ public struct HCIReadLMPHandle: HCICommandParameter {
         self.handle = handle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1])
+        data += [handleBytes.0, handleBytes.1]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIReadLocalName.swift
+++ b/Sources/BluetoothHCI/HCIReadLocalName.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIReadLocalSupportedFeatures.swift
+++ b/Sources/BluetoothHCI/HCIReadLocalSupportedFeatures.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIReadLocalVersionInformation.swift
+++ b/Sources/BluetoothHCI/HCIReadLocalVersionInformation.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIReadPageTimeout.swift
+++ b/Sources/BluetoothHCI/HCIReadPageTimeout.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCIReadRemoteExtendedFeatures.swift
+++ b/Sources/BluetoothHCI/HCIReadRemoteExtendedFeatures.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -52,10 +50,10 @@ public struct HCIReadRemoteExtendedFeatures: HCICommandParameter {
         self.pageNumber = pageNumber
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1, pageNumber])
+        data += [handleBytes.0, handleBytes.1, pageNumber]
     }
 }

--- a/Sources/BluetoothHCI/HCIReadRemoteExtendedFeaturesComplete.swift
+++ b/Sources/BluetoothHCI/HCIReadRemoteExtendedFeaturesComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Read Remote Extended Features Complete Event
 ///
 /// The Read Remote Extended Features Complete event is used to indicate the completion of the process of the Link Manager obtaining the remote extended LMP features of the remote device specified by the Connection_Handle event parameter. The Connection_Handle will be a Connection_Handle for an ACL connection. The event parameters include a page of the remote devices extended LMP features.

--- a/Sources/BluetoothHCI/HCIReadRemoteFeaturesComplete.swift
+++ b/Sources/BluetoothHCI/HCIReadRemoteFeaturesComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Read Remote Supported Features Complete Event
 ///
 /// The Read Remote Supported Features Complete event is used to indicate the completion of the process of the Link Manager obtaining the supported features of the remote BR/EDR Controller specified by the Connection_Handle event parameter. The Connection_Handle will be a Connection_Handle for an ACL connection. The event parameters include a list of LMP features

--- a/Sources/BluetoothHCI/HCIReadRemoteSupportedFeatures.swift
+++ b/Sources/BluetoothHCI/HCIReadRemoteSupportedFeatures.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -48,10 +46,10 @@ public struct HCIReadRemoteSupportedFeatures: HCICommandParameter {
         self.handle = handle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1])
+        data += [handleBytes.0, handleBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCIReadRemoteVersionInformation.swift
+++ b/Sources/BluetoothHCI/HCIReadRemoteVersionInformation.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -47,10 +45,10 @@ public struct HCIReadRemoteVersionInformation: HCICommandParameter {
         self.handle = handle
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1])
+        data += [handleBytes.0, handleBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCIReadRemoteVersionInformationComplete.swift
+++ b/Sources/BluetoothHCI/HCIReadRemoteVersionInformationComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Read Remote Extended Features Complete Event
 ///
 /// The Read Remote Extended Features Complete event is used to indicate the completion of the process of the Link Manager obtaining the remote extended LMP features of the remote device specified by the Connection_Handle event parameter. The Connection_Handle will be a Connection_Handle for an ACL connection. The event parameters include a page of the remote devices extended LMP features.

--- a/Sources/BluetoothHCI/HCIReadStoredLinkKey.swift
+++ b/Sources/BluetoothHCI/HCIReadStoredLinkKey.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -49,11 +47,11 @@ public struct HCIReadStoredLinkKey: HCICommandParameter {
         self.readFlag = readFlag
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
@@ -61,7 +59,7 @@ public struct HCIReadStoredLinkKey: HCICommandParameter {
             addressBytes.4,
             addressBytes.5,
             readFlag.rawValue
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIRejectConnectionRequest.swift
+++ b/Sources/BluetoothHCI/HCIRejectConnectionRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -48,10 +46,10 @@ public struct HCIRejectConnectionRequest: HCICommandParameter {
         self.error = error
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([addressBytes.0, addressBytes.1, addressBytes.2, addressBytes.3, addressBytes.4, addressBytes.5, error.rawValue])
+        data += [addressBytes.0, addressBytes.1, addressBytes.2, addressBytes.3, addressBytes.4, addressBytes.5, error.rawValue]
     }
 }

--- a/Sources/BluetoothHCI/HCIRemoteNameRequest.swift
+++ b/Sources/BluetoothHCI/HCIRemoteNameRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -91,13 +89,13 @@ public struct HCIRemoteNameRequest: HCICommandParameter {
         self.clockOffset = ClockOffset(rawValue: UInt16(littleEndian: UInt16(bytes: (data[8], data[9]))))
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
         let clockOffsetBytes = clockOffset.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
@@ -108,7 +106,7 @@ public struct HCIRemoteNameRequest: HCICommandParameter {
             reserved.rawValue,
             clockOffsetBytes.0,
             clockOffsetBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIRemoteNameRequestComplete.swift
+++ b/Sources/BluetoothHCI/HCIRemoteNameRequestComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// HCI Remote Name Request Complete Event
 @frozen
 public struct HCIRemoteNameRequestComplete: HCIEventParameter {

--- a/Sources/BluetoothHCI/HCIReset.swift
+++ b/Sources/BluetoothHCI/HCIReset.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/HCISetConnectionEncryption.swift
+++ b/Sources/BluetoothHCI/HCISetConnectionEncryption.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -47,11 +45,11 @@ public struct HCISetConnectionEncryption: HCICommandParameter {
         self.encryption = encryption
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
-        return Data([handleBytes.0, handleBytes.1, encryption.rawValue])
+        data += [handleBytes.0, handleBytes.1, encryption.rawValue]
     }
 }
 

--- a/Sources/BluetoothHCI/HCISetEventFilter.swift
+++ b/Sources/BluetoothHCI/HCISetEventFilter.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Command
 
 /// Set Event Filter Command
@@ -49,7 +47,7 @@ public struct HCISetEventFilter: HCICommandParameter {
     ///
     public var filterType: FilterType  // Filter_Type
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         fatalError("\(#function) TODO")
     }

--- a/Sources/BluetoothHCI/HCISimplePairingComplete.swift
+++ b/Sources/BluetoothHCI/HCISimplePairingComplete.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The Simple Pairing Complete event is used to indicate that the simple pairing process has completed. A Host that is displaying a numeric value can use this event to change its UI.
 ///
 /// When the LMP simple pairing sequences fail for any reason, the Simple Pairing Complete event shall be sent to the Host. When Simple Pairing Complete event is sent in response to the IO capability exchange failing, the Status parameter shall be set to the error code received from the remote device. Oth- erwise, the Status shall be set to the error code “Authentication Failure.”

--- a/Sources/BluetoothHCI/HCIUserConfirmationRequest.swift
+++ b/Sources/BluetoothHCI/HCIUserConfirmationRequest.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The User Confirmation Request event is used to indicate that user confirmation of a numeric value is required. The Host shall reply with either the User_Confirmation_Request_Reply or the User_Confirmation_Request_Negative_Reply command. If the Host has output capability (DisplayYesNo or KeyboardOnly), it shall display the Numeric_Value until the Simple Pairing Complete event is received. It shall reply based on the yes/no response from the user. If the Host has no input and no output it shall reply with the User Confirmation Request Reply command. When the Controller generates a User Confirmation Request event, in order for the local Link Manager to respond to the request from the remote Link Manager, the local Host must respond with either a User_Confirmation_Request_Reply or a User_Confirmation_Request_Negative_Reply command before the remote Link Manager detects LMP response timeout.
 @frozen
 public struct HCIUserConfirmationRequest: HCIEventParameter {

--- a/Sources/BluetoothHCI/HCIUserConfirmationRequestReply.swift
+++ b/Sources/BluetoothHCI/HCIUserConfirmationRequestReply.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -41,18 +39,18 @@ public struct HCIUserConfirmationRequestReply: HCICommandParameter {
         self.address = address
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let addressBytes = address.littleEndian.bytes
 
-        return Data([
+        data += [
             addressBytes.0,
             addressBytes.1,
             addressBytes.2,
             addressBytes.3,
             addressBytes.4,
             addressBytes.5
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIWriteClassOfDevice.swift
+++ b/Sources/BluetoothHCI/HCIWriteClassOfDevice.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -43,8 +41,8 @@ public struct HCIWriteClassOfDevice: HCICommandParameter {
         self.classOfDevice = classOfDevice
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data(classOfDevice)
+        data += classOfDevice
     }
 }

--- a/Sources/BluetoothHCI/HCIWriteConnectionAcceptTimeout.swift
+++ b/Sources/BluetoothHCI/HCIWriteConnectionAcceptTimeout.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Write Connection Accept Timeout Command
 ///
 /// This command writes the value for the Connection Accept Timeout configuration parameter.
@@ -23,10 +21,10 @@ public struct HCIWriteConnectionAcceptTimeout: HCICommandParameter {
         self.timeout = timeout
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let timeoutBytes = timeout.rawValue.littleEndian.bytes
 
-        return Data([timeoutBytes.0, timeoutBytes.1])
+        data += [timeoutBytes.0, timeoutBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCIWriteLinkPolicySettings.swift
+++ b/Sources/BluetoothHCI/HCIWriteLinkPolicySettings.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -53,17 +51,17 @@ public struct HCIWriteLinkPolicySettings: HCICommandParameter {
         self.settings = settings
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = connectionHandle.littleEndian.bytes
         let settingsBytes = settings.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             handleBytes.0,
             handleBytes.1,
             settingsBytes.0,
             settingsBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIWriteLinkSupervisionTimeout.swift
+++ b/Sources/BluetoothHCI/HCIWriteLinkSupervisionTimeout.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -57,18 +55,18 @@ public struct HCIWriteLinkSupervisionTimeout: HCICommandParameter {
         self.linkSupervisionTimeout = linkSupervisionTimeout
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let handleBytes = handle.littleEndian.bytes
 
         let timeoutBytes = linkSupervisionTimeout.rawValue.littleEndian.bytes
 
-        return Data([
+        data += [
             handleBytes.0,
             handleBytes.1,
             timeoutBytes.0,
             timeoutBytes.1
-        ])
+        ]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIWriteLocalName.swift
+++ b/Sources/BluetoothHCI/HCIWriteLocalName.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -44,19 +42,18 @@ public struct HCIWriteLocalName: HCICommandParameter {
         self.localName = localName
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let maxLength = Self.length
+        let utf8 = localName.utf8
 
-        var data = Data(localName.utf8)
+        assert(utf8.count <= maxLength)
 
-        assert(data.count <= maxLength)
+        data += utf8
 
-        if data.count < maxLength {
+        if utf8.count < maxLength {
 
-            data += Data(repeating: 0x00, count: maxLength - data.count)
+            data += repeatElement(0x00, count: maxLength - utf8.count)
         }
-
-        return data
     }
 }

--- a/Sources/BluetoothHCI/HCIWritePageScanActivity.swift
+++ b/Sources/BluetoothHCI/HCIWritePageScanActivity.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -49,13 +47,13 @@ public struct HCIWritePageScanActivity: HCICommandParameter {
         self.scanWindow = scanWindow
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let intervalBytes = scanInterval.rawValue.littleEndian.bytes
 
         let windowBytes = scanWindow.rawValue.littleEndian.bytes
 
-        return Data([intervalBytes.0, intervalBytes.1, windowBytes.0, windowBytes.1])
+        data += [intervalBytes.0, intervalBytes.1, windowBytes.0, windowBytes.1]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIWritePageScanType.swift
+++ b/Sources/BluetoothHCI/HCIWritePageScanType.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -43,9 +41,9 @@ public struct HCIWritePageScanType: HCICommandParameter {
         self.pageScanType = pageScanType
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([pageScanType.rawValue])
+        data += [pageScanType.rawValue]
     }
 }
 

--- a/Sources/BluetoothHCI/HCIWritePageTimeout.swift
+++ b/Sources/BluetoothHCI/HCIWritePageTimeout.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -45,10 +43,10 @@ public struct HCIWritePageTimeout: HCICommandParameter {
         self.pageTimeout = pageTimeout
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
         let pageTimeoutBytes = pageTimeout.rawValue.littleEndian.bytes
 
-        return Data([pageTimeoutBytes.0, pageTimeoutBytes.1])
+        data += [pageTimeoutBytes.0, pageTimeoutBytes.1]
     }
 }

--- a/Sources/BluetoothHCI/HCIWriteScanEnable.swift
+++ b/Sources/BluetoothHCI/HCIWriteScanEnable.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - Method
 
 public extension BluetoothHostControllerInterface {
@@ -43,9 +41,9 @@ public struct HCIWriteScanEnable: HCICommandParameter {
         self.scanEnable = scanEnable
     }
 
-    public var data: Data {
+    public func append<Data: DataContainer>(to data: inout Data) {
 
-        return Data([scanEnable.rawValue])
+        data += [scanEnable.rawValue]
     }
 }
 

--- a/Sources/BluetoothHCI/InformationalCommand.swift
+++ b/Sources/BluetoothHCI/InformationalCommand.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 @frozen
 public enum InformationalCommand: UInt16, HCICommand {
 

--- a/Sources/BluetoothHCI/LMPFeature.swift
+++ b/Sources/BluetoothHCI/LMPFeature.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// Bluetooth LMP Feature
 @frozen
 public enum LMPFeature: UInt64, BitMaskOption {

--- a/Sources/BluetoothHCI/LowEnergyAdvertising.swift
+++ b/Sources/BluetoothHCI/LowEnergyAdvertising.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 // MARK: - BluetoothHostControllerInterface
 
 public extension BluetoothHostControllerInterface {

--- a/Sources/BluetoothHCI/PacketType.swift
+++ b/Sources/BluetoothHCI/PacketType.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 /// The packets used on the piconet are related to the logical transports they are used in. Three logical transports with distinct packet types are defined (see Section 4 on page 97): the SCO logical transport, the eSCO logical transport, and the ACL logical transport. For each of these logical transports, 15 different packet types can be defined.
 ///
 /// To indicate the different packets on a logical transport, the 4-bit TYPE code is used. The packet types are divided into four segments. The first segment is reserved for control packets. All control packets occupy a single time slot. The sec- ond segment is reserved for packets occupying a single time slot. The third seg- ment is reserved for packets occupying three time slots. The fourth segment is reserved for packets occupying five time slots. The slot occupancy is reflected in the segmentation and can directly be derived from the type code. Table 6.2 on page 118 summarizes the packets defined for the SCO, eSCO, and ACL logical transport types.

--- a/Sources/BluetoothHCI/VendorCommand.swift
+++ b/Sources/BluetoothHCI/VendorCommand.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-import Foundation
-
 @frozen
 public struct VendorCommand: HCICommand, Equatable, Hashable {
 

--- a/Sources/BluetoothHCI/iBeacon.swift
+++ b/Sources/BluetoothHCI/iBeacon.swift
@@ -5,7 +5,6 @@
 //  Created by Alsey Coleman Miller on 10/22/20.
 //
 
-import Foundation
 import Bluetooth
 import BluetoothGAP
 

--- a/Tests/BluetoothTests/HostController.swift
+++ b/Tests/BluetoothTests/HostController.swift
@@ -365,4 +365,18 @@ extension Array {
         return first
     }
 }
+
+internal extension HCICommandParameter {
+
+    var data: Data {
+        Data(self)
+    }
+}
+
+internal extension HCIPacketHeader {
+
+    var data: Data {
+        Data(self)
+    }
+}
 #endif


### PR DESCRIPTION
## What changed

Finishes the encode-side `DataContainer` migration for the HCI layer (#161), the counterpart to #206 for BluetoothGATT.

- `HCICommandParameter` now requires the generic `func append<Data: DataContainer>(to:)` instead of Foundation's `var data: Data`, and `HCIPacketHeader` (command/event headers) gets the same treatment. `DataContainer` gains `init<T: HCICommandParameter>(_:)` and `init<T: HCIPacketHeader>(_:)` for building buffers.
- All 91 command/header encoders migrated to the generic API. Types that were already `DataConvertible` (e.g. `HCILECreateConnection`, `HCILEEncrypt`, `HCILEAddDeviceToWhiteList`) now encode through their existing `append` directly, dropping the redundant Foundation wrappers.
- `import Foundation` removed from **167 of 172** files. The remaining five (`BluetoothHostController`, `HCILESetScanEnable`, `HCIError`, `HCIPacketHeader`, `HCICommandTimeout`) genuinely use `Foundation.Data`/`TimeInterval`/`CustomNSError` in the host-controller runtime and are left for a follow-up.
- `HCIWriteLocalName` encodes UTF-8 + zero padding without constructing intermediate `Foundation.Data`; the crashing `HCISetEventFilter` stub keeps its `fatalError` but under the new signature (implementing it is tracked separately).

### Not in scope

Making the host-controller runtime (`deviceRequest`/`receive`, `garbageResponse(Data)`) generic over `DataContainer` — that is a deeper refactor of the async I/O surface.

## Reviewer notes

- **Source-breaking:** command parameters and packet headers no longer expose `.data` — use `Data(parameter)` instead (the test target bridges this internally).
- Encoder bodies were transformed mechanically (`return Data([…])` → `data += […]`, builder pattern → direct appends); byte order and field order are unchanged.
- All 279 tests pass in debug and the module lints clean (`swift format lint`, `swiftlint`).