### PR TITLE
Fix Set Default PHY opcode and implement Set Event Filter

### DIFF
--- a/Sources/BluetoothHCI/HCILEAdvertisingReport.swift
+++ b/Sources/BluetoothHCI/HCILEAdvertisingReport.swift
@@ -18,16 +18,15 @@ public struct HCILEAdvertisingReport: HCIEventParameter, Equatable, Hashable, Se
 
     public static var event: LowEnergyEvent { .advertisingReport }  // 0x02
 
-    internal static var minLength: Int { 1 + Report.length }  // must have at least one report
-
-    // TODO: Allow variable size
-    public static var length: Int { Self.minLength }
+    /// The event is variable-length and may contain up to 25 reports;
+    /// this is the minimum valid size (a single report with no response data).
+    public static var length: Int { 1 + Report.length }
 
     public let reports: [Report]
 
     public init?<Data: DataContainer>(data: Data) {
 
-        guard data.count >= Self.minLength
+        guard data.count >= Self.length
         else { return nil }
 
         // Number of responses in event.

--- a/Sources/BluetoothHCI/HCILESetDefaultPhy.swift
+++ b/Sources/BluetoothHCI/HCILESetDefaultPhy.swift
@@ -37,7 +37,7 @@ public extension BluetoothHostControllerInterface {
 @frozen
 public struct HCILESetDefaultPhy: HCICommandParameter {
 
-    public static let command = HCILowEnergyCommand.readPhy  //0x0031
+    public static let command = HCILowEnergyCommand.setDefaultPhy  // 0x0031
 
     public let allPhys: LowEnergyAllPhys
     public let txPhys: LowEnergyTxPhys

--- a/Sources/BluetoothHCI/HCISetEventFilter.swift
+++ b/Sources/BluetoothHCI/HCISetEventFilter.swift
@@ -40,19 +40,60 @@
 ///
 /// If there is a contradiction between event filters, the latest set event filter will override older ones. An example is an incoming connection attempt where more than one Connection Setup filter matches the incoming connection attempt, but the Auto-Accept_Flag has different values in the different filters.
 @frozen
-public struct HCISetEventFilter: HCICommandParameter {
+public struct HCISetEventFilter: HCICommandParameter, Equatable, Sendable {
 
     public static let command = HostControllerBasebandCommand.setEventFilter
 
-    ///
-    public var filterType: FilterType  // Filter_Type
+    /// The event filter to set.
+    public var filter: Filter
+
+    public init(filter: Filter) {
+
+        self.filter = filter
+    }
 
     public func append<Data: DataContainer>(to data: inout Data) {
 
-        fatalError("\(#function) TODO")
+        switch filter {
+
+        case .clearAll:
+            data += FilterType.clearAll.rawValue
+
+        case let .inquiryResult(condition):
+            data += FilterType.inquiryResult.rawValue
+            switch condition {
+            case .all:
+                data += InquiryResultFilterConditionType.all.rawValue
+            case let .classOfDevice(classOfDevice, mask):
+                data += InquiryResultFilterConditionType.classOfDevice.rawValue
+                classOfDevice.append(to: &data)
+                let maskBytes = mask.littleEndian.bytes
+                data += [maskBytes.0, maskBytes.1, maskBytes.2]
+            case let .address(address):
+                data += InquiryResultFilterConditionType.address.rawValue
+                data += address.littleEndian
+            }
+
+        case let .connectionSetup(condition, autoAccept):
+            data += FilterType.connectionSetup.rawValue
+            switch condition {
+            case .all:
+                data += ConnectionSetupFilterConditionType.all.rawValue
+            case let .classOfDevice(classOfDevice, mask):
+                data += ConnectionSetupFilterConditionType.classOfDevice.rawValue
+                classOfDevice.append(to: &data)
+                let maskBytes = mask.littleEndian.bytes
+                data += [maskBytes.0, maskBytes.1, maskBytes.2]
+            case let .address(address):
+                data += ConnectionSetupFilterConditionType.address.rawValue
+                data += address.littleEndian
+            }
+            data += autoAccept.rawValue
+        }
     }
 
-    public enum FilterType: UInt8 {
+    /// Event filter and its filter condition.
+    public enum Filter: Equatable, Sendable {
 
         /// Clear All Filters
         ///
@@ -60,6 +101,19 @@ public struct HCISetEventFilter: HCICommandParameter {
         /// they should have a length of 0 octets.
         ///
         /// Filter_Type should be the only parameter.
+        case clearAll
+
+        /// Inquiry Result.
+        case inquiryResult(InquiryResultFilterCondition)
+
+        /// Connection Setup
+        case connectionSetup(ConnectionSetupFilterCondition, autoAccept: AutoAcceptFlag)
+    }
+
+    /// Filter_Type
+    public enum FilterType: UInt8 {
+
+        /// Clear All Filters
         case clearAll = 0x00
 
         /// Inquiry Result.
@@ -69,7 +123,8 @@ public struct HCISetEventFilter: HCICommandParameter {
         case connectionSetup = 0x02
     }
 
-    public enum InquiryResultFilterConditionType: UInt8 {
+    /// Filter condition for the Inquiry Result filter.
+    public enum InquiryResultFilterCondition: Equatable, Sendable {
 
         /// Return responses from all devices during the Inquiry process.
         ///
@@ -79,9 +134,84 @@ public struct HCISetEventFilter: HCICommandParameter {
         case all
 
         /// A device with a specific Class of Device responded to the Inquiry process.
-        case classOfDevice
+        case classOfDevice(ClassOfDevice, mask: UInt24)
 
         /// A device with a specific `BD_ADDR` responded to the Inquiry process.
-        case address
+        case address(BluetoothAddress)
+    }
+
+    /// Filter condition for the Connection Setup filter.
+    public enum ConnectionSetupFilterCondition: Equatable, Sendable {
+
+        /// Allow Connections from all devices.
+        case all
+
+        /// Allow Connections from a device with a specific Class of Device.
+        case classOfDevice(ClassOfDevice, mask: UInt24)
+
+        /// Allow Connections from a device with a specific `BD_ADDR`.
+        case address(BluetoothAddress)
+    }
+
+    /// Filter_Condition_Type for the Inquiry Result filter.
+    public enum InquiryResultFilterConditionType: UInt8 {
+
+        /// Return responses from all devices during the Inquiry process.
+        case all = 0x00
+
+        /// A device with a specific Class of Device responded to the Inquiry process.
+        case classOfDevice = 0x01
+
+        /// A device with a specific `BD_ADDR` responded to the Inquiry process.
+        case address = 0x02
+    }
+
+    /// Filter_Condition_Type for the Connection Setup filter.
+    public enum ConnectionSetupFilterConditionType: UInt8 {
+
+        /// Allow Connections from all devices.
+        case all = 0x00
+
+        /// Allow Connections from a device with a specific Class of Device.
+        case classOfDevice = 0x01
+
+        /// Allow Connections from a device with a specific `BD_ADDR`.
+        case address = 0x02
+    }
+
+    /// Auto_Accept_Flag
+    ///
+    /// Specifies what action should be done when a Connection Setup filter condition is met.
+    public enum AutoAcceptFlag: UInt8, Equatable, Hashable, Sendable {
+
+        /// Do NOT Auto accept the connection. (Auto accept is off)
+        case off = 0x01
+
+        /// Do Auto accept the connection with role switch disabled. (Auto accept is on)
+        case on = 0x02
+
+        /// Do Auto accept the connection with role switch enabled. (Auto accept is on)
+        ///
+        /// - Note: When auto accepting an incoming SCO or eSCO connection, this option shall be
+        /// treated the same as `on`.
+        case onWithRoleSwitch = 0x03
+    }
+}
+
+// MARK: - Method
+
+public extension BluetoothHostControllerInterface {
+
+    /// Set Event Filter Command
+    ///
+    /// Used by the Host to specify different event filters.
+    func setEventFilter(
+        _ filter: HCISetEventFilter.Filter,
+        timeout: HCICommandTimeout = .default
+    ) async throws {
+
+        let command = HCISetEventFilter(filter: filter)
+
+        try await deviceRequest(command, timeout: timeout)
     }
 }

--- a/Tests/BluetoothTests/HCITests.swift
+++ b/Tests/BluetoothTests/HCITests.swift
@@ -3179,6 +3179,74 @@ import Foundation
         #expect(event.status.rawValue == 0x00)
         #expect(event.address == BluetoothAddress(rawValue: "B0:70:2D:06:D2:AF")!)
     }
+
+    @Test func setDefaultPhyOpcode() {
+
+        // LE Set Default PHY is 0x0031; Read PHY is 0x0030
+        #expect(HCILESetDefaultPhy.command == .setDefaultPhy)
+        #expect(HCILESetDefaultPhy.command.rawValue == 0x0031)
+    }
+
+    @Test func setEventFilter() {
+
+        let address = BluetoothAddress(rawValue: "B0:70:2D:06:D2:AF")!
+        let addressBytes: [UInt8] = [0xaf, 0xd2, 0x06, 0x2d, 0x70, 0xb0]
+
+        guard let classOfDevice = ClassOfDevice(data: Data([0x0c, 0x02, 0x7a]))
+        else {
+            Issue.record("Unable to init classOfDevice")
+            return
+        }
+        let classOfDeviceBytes = [UInt8](Data(classOfDevice))
+        let mask: UInt24 = 0xFFFFFF
+
+        // Clear All Filters
+        #expect(Data(HCISetEventFilter(filter: .clearAll)) == Data([0x00]))
+
+        // Inquiry Result: all devices
+        #expect(Data(HCISetEventFilter(filter: .inquiryResult(.all))) == Data([0x01, 0x00]))
+
+        // Inquiry Result: specific Class of Device
+        #expect(
+            Data(HCISetEventFilter(filter: .inquiryResult(.classOfDevice(classOfDevice, mask: mask))))
+                == Data([0x01, 0x01] + classOfDeviceBytes + [0xff, 0xff, 0xff]))
+
+        // Inquiry Result: specific address
+        #expect(
+            Data(HCISetEventFilter(filter: .inquiryResult(.address(address))))
+                == Data([0x01, 0x02] + addressBytes))
+
+        // Connection Setup: all devices, auto accept with role switch
+        #expect(
+            Data(HCISetEventFilter(filter: .connectionSetup(.all, autoAccept: .onWithRoleSwitch)))
+                == Data([0x02, 0x00, 0x03]))
+
+        // Connection Setup: specific Class of Device, no auto accept
+        #expect(
+            Data(HCISetEventFilter(filter: .connectionSetup(.classOfDevice(classOfDevice, mask: mask), autoAccept: .off)))
+                == Data([0x02, 0x01] + classOfDeviceBytes + [0xff, 0xff, 0xff, 0x01]))
+
+        // Connection Setup: specific address, auto accept
+        #expect(
+            Data(HCISetEventFilter(filter: .connectionSetup(.address(address), autoAccept: .on)))
+                == Data([0x02, 0x02] + addressBytes + [0x02]))
+    }
+
+    @Test func setEventFilterCommand() async throws {
+
+        let hostController = TestHostController()
+
+        // clear all filters: opcode 0x0C05, parameter [0x00]
+        hostController.queue.append(
+            .command(
+                HostControllerBasebandCommand.setEventFilter.opcode,
+                [0x05, 0x0C, 0x01, 0x00]))
+
+        // command complete
+        hostController.queue.append(.event([0x0E, 0x04, 0x01, 0x05, 0x0C, 0x00]))
+
+        try await hostController.setEventFilter(.clearAll)
+    }
 }
 
 @_silgen_name("swift_bluetooth_parse_event")


### PR DESCRIPTION
Fixes two defects found during the HCI audit, plus a stale TODO. Builds on the generic `append(to:)` encoding API from #207.

## What changed

1. **Wrong opcode (functional bug):** `HCILESetDefaultPhy` was bound to `HCILowEnergyCommand.readPhy` (0x0030) instead of `.setDefaultPhy` (0x0031), so `lowEnergySetDefaultPhy(...)` sent the LE Read PHY command. One-line fix, with a regression test asserting the opcode.

2. **`HCISetEventFilter` implemented** (was a `fatalError` stub with no condition fields). Per Core Spec Vol 4 Part E §7.3.3:
   - `Filter` enum models Clear All, Inquiry Result, and Connection Setup filters.
   - Inquiry Result / Connection Setup conditions: all devices, specific `ClassOfDevice` + 3-byte mask (`UInt24`), or specific `BluetoothAddress`.
   - Connection Setup carries the `Auto_Accept_Flag` (off / on / on with role switch).
   - New `setEventFilter(_:timeout:)` convenience method on `BluetoothHostControllerInterface`.
   - Encoding tests cover all seven filter/condition shapes, plus a mock host-controller round trip for the command.

3. **`HCILEAdvertisingReport`:** resolved the "allow variable size" TODO — the event is inherently variable-length (1–25 reports) and the decoder already handles that; `length` is now documented and defined as the minimum valid size instead of carrying a misleading TODO.

## Notes

- The old `HCISetEventFilter.filterType` property and its unusable partial enums are replaced; the type previously crashed on encode, so no working code could depend on it.
- All 282 tests pass; `swift format lint` and `swiftlint` clean.