### PR TITLE
Add Bluetooth 5.4 GATT characteristics

### DIFF
--- a/Sources/BluetoothGATT/GATTEncryptedDataKeyMaterial.swift
+++ b/Sources/BluetoothGATT/GATTEncryptedDataKeyMaterial.swift
@@ -1,0 +1,82 @@
+//
+//  GATTEncryptedDataKeyMaterial.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// Encrypted Data Key Material
+///
+/// The Encrypted Data Key Material characteristic provides the key material used
+/// with the Encrypted Advertising Data feature (Bluetooth Core 5.4): a 16-octet
+/// session key and an 8-octet initialization vector.
+///
+/// A GATT client may read this value over an encrypted and authenticated connection only,
+/// and the characteristic may support indications to notify clients when the key material
+/// changes. Enforcing those security requirements is the responsibility of the GATT server
+/// configuration, not this type.
+///
+/// - Note: This type only carries the key material; encryption and decryption of
+/// advertising payloads (CCM) is out of scope for this library.
+///
+/// - SeeAlso: [Bluetooth Core Specification](https://www.bluetooth.com/specifications/specs/) Vol 3 Part C 12.6
+@frozen
+public struct GATTEncryptedDataKeyMaterial: GATTCharacteristic, Equatable, Hashable, Sendable {
+
+    internal static let length = MemoryLayout<UInt128>.size + MemoryLayout<UInt64>.size
+
+    public static var uuid: BluetoothUUID { BluetoothUUID.Characteristic.encryptedDataKeyMaterial }
+
+    /// Session Key (16 octets)
+    public var sessionKey: UInt128
+
+    /// Initialization Vector (8 octets)
+    public var initializationVector: UInt64
+
+    public init(sessionKey: UInt128, initializationVector: UInt64) {
+
+        self.sessionKey = sessionKey
+        self.initializationVector = initializationVector
+    }
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count == Self.length
+        else { return nil }
+
+        guard let sessionKey = UInt128(data: data.subdata(in: 0..<MemoryLayout<UInt128>.size))
+        else { return nil }
+
+        let ivOffset = MemoryLayout<UInt128>.size
+        let initializationVector = UInt64(
+            littleEndian: UInt64(
+                bytes: (
+                    data[ivOffset],
+                    data[ivOffset + 1],
+                    data[ivOffset + 2],
+                    data[ivOffset + 3],
+                    data[ivOffset + 4],
+                    data[ivOffset + 5],
+                    data[ivOffset + 6],
+                    data[ivOffset + 7]
+                )))
+
+        self.init(
+            sessionKey: UInt128(littleEndian: sessionKey),
+            initializationVector: initializationVector)
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        data += sessionKey.littleEndian
+        data += initializationVector.littleEndian
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
+    }
+}

--- a/Sources/BluetoothGATT/GATTLESecurityLevels.swift
+++ b/Sources/BluetoothGATT/GATTLESecurityLevels.swift
@@ -1,0 +1,97 @@
+//
+//  GATTLESecurityLevels.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// LE GATT Security Levels
+///
+/// The LE GATT Security Levels characteristic (Bluetooth Core 5.4) allows clients to
+/// determine the security conditions which must be satisfied for access to all GATT
+/// server functionality to be granted, before accessing the attributes the application
+/// uses. The value is an array of one or more Security Level Requirements fields, each
+/// consisting of a security mode and a security level.
+///
+/// The characteristic allows read access to its value without further security
+/// restrictions, such as the need for the link to be encrypted.
+///
+/// - SeeAlso: [Bluetooth Core Specification](https://www.bluetooth.com/specifications/specs/) Vol 3 Part C 12.7
+@frozen
+public struct GATTLESecurityLevels: GATTCharacteristic, Equatable, Hashable, Sendable {
+
+    public static var uuid: BluetoothUUID { BluetoothUUID.Characteristic.leGattSecurityLevels }
+
+    /// Security Level Requirements which will satisfy the security requirements
+    /// of all attributes of the server.
+    public var requirements: [Requirement]
+
+    public init?(requirements: [Requirement]) {
+
+        guard requirements.isEmpty == false
+        else { return nil }
+
+        self.requirements = requirements
+    }
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        let length = MemoryLayout<UInt8>.size * 2
+
+        guard data.count >= length,
+            data.count % length == 0
+        else { return nil }
+
+        var requirements = [Requirement]()
+        requirements.reserveCapacity(data.count / length)
+
+        var offset = 0
+        while offset < data.count {
+            requirements.append(
+                Requirement(
+                    mode: data[offset],
+                    level: data[offset + 1]
+                ))
+            offset += length
+        }
+
+        self.init(requirements: requirements)
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        for requirement in requirements {
+            data += requirement.mode
+            data += requirement.level
+        }
+    }
+
+    public var dataLength: Int {
+
+        return requirements.count * 2
+    }
+
+    /// Security Level Requirements field.
+    ///
+    /// A combination of an LE security mode (e.g. `0x01` for LE security mode 1)
+    /// and a security level within that mode (e.g. `0x04` for security level 4).
+    /// Raw values are stored so that values defined in future specification
+    /// versions round-trip losslessly.
+    public struct Requirement: Equatable, Hashable, Sendable {
+
+        /// LE Security Mode (e.g. `0x01` for LE security mode 1)
+        public var mode: UInt8
+
+        /// Security Level (e.g. `0x04` for security level 4)
+        public var level: UInt8
+
+        public init(mode: UInt8, level: UInt8) {
+
+            self.mode = mode
+            self.level = level
+        }
+    }
+}

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -1594,6 +1594,67 @@ import Bluetooth
         #expect(GATTObjectID.uuid == BluetoothUUID.Characteristic.objectId)
         #expect(GATTObjectID(data: data) == GATTObjectID(data: data))
     }
+
+    @Test func encryptedDataKeyMaterial() {
+
+        // 16-byte session key (little endian) + 8-byte IV (little endian)
+        let data = Data([
+            // Session Key
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+            // IV
+            0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17
+        ])
+
+        guard let characteristic = GATTEncryptedDataKeyMaterial(data: data)
+        else {
+            Issue.record("Could not decode from bytes")
+            return
+        }
+
+        roundTrip(characteristic, encodes: data)
+        #expect(characteristic.initializationVector == 0x1716_1514_1312_1110)
+        #expect(GATTEncryptedDataKeyMaterial.uuid == BluetoothUUID.Characteristic.encryptedDataKeyMaterial)
+        #expect(GATTEncryptedDataKeyMaterial(data: data) == GATTEncryptedDataKeyMaterial(data: data))
+
+        // invalid length
+        #expect(GATTEncryptedDataKeyMaterial(data: Data([0x00])) == nil)
+        #expect(GATTEncryptedDataKeyMaterial(data: data.prefix(23)) == nil)
+    }
+
+    @Test func leSecurityLevels() {
+
+        // LE security mode 1 level 4, mode 2 level 2
+        let data = Data([0x01, 0x04, 0x02, 0x02])
+
+        guard let characteristic = GATTLESecurityLevels(data: data)
+        else {
+            Issue.record("Could not decode from bytes")
+            return
+        }
+
+        roundTrip(characteristic, encodes: data)
+        #expect(characteristic.requirements.count == 2)
+        #expect(characteristic.requirements[0] == GATTLESecurityLevels.Requirement(mode: 0x01, level: 0x04))
+        #expect(characteristic.requirements[1] == GATTLESecurityLevels.Requirement(mode: 0x02, level: 0x02))
+        #expect(GATTLESecurityLevels.uuid == BluetoothUUID.Characteristic.leGattSecurityLevels)
+        #expect(GATTLESecurityLevels(data: data) == GATTLESecurityLevels(data: data))
+
+        // single pair
+        let single = Data([0x01, 0x02])
+        guard let singleCharacteristic = GATTLESecurityLevels(data: single)
+        else {
+            Issue.record("Could not decode from bytes")
+            return
+        }
+        roundTrip(singleCharacteristic, encodes: single)
+
+        // invalid: empty or odd length
+        #expect(GATTLESecurityLevels(data: Data()) == nil)
+        #expect(GATTLESecurityLevels(data: Data([0x01])) == nil)
+        #expect(GATTLESecurityLevels(data: Data([0x01, 0x04, 0x02])) == nil)
+        #expect(GATTLESecurityLevels(requirements: []) == nil)
+    }
 }
 
 internal extension GATTCharacteristic {


### PR DESCRIPTION
Phase 1 of Bluetooth Core 5.4 support: the two new GATT characteristics. Their UUIDs were already present in the assigned-numbers metadata; this adds the typed implementations following the `GATTCharacteristic: DataConvertible` pattern from #206.

## What changed

- **`GATTEncryptedDataKeyMaterial`** (`0x2B88`) — fixed 24 octets: 16-byte session key (`UInt128`) + 8-byte initialization vector (`UInt64`), little-endian. Used by the Encrypted Advertising Data feature to share key material over an encrypted, authenticated connection. Payload encryption (CCM) is intentionally out of scope for this package.
- **`GATTLESecurityLevels`** (`0x2BF5`) — variable-length array of Security Level Requirements pairs (`mode`, `level` as raw `UInt8` so future values round-trip). Rejects empty and odd-length values.

## Tests

Round-trip tests through `Foundation.Data`, `[UInt8]`, and `LowEnergyAdvertisingData` via the existing `roundTrip` helper, plus invalid-length rejection cases. Full suite: 281 tests pass; lint clean.