### PR TITLE
Add Advertising Coding Selection (Bluetooth 5.4)

### DIFF
--- a/Sources/BluetoothHCI/HCILEExtendedAdvertisingReport.swift
+++ b/Sources/BluetoothHCI/HCILEExtendedAdvertisingReport.swift
@@ -198,7 +198,15 @@ public struct HCILEExtendedAdvertisingReport<ReportData: DataContainer>: HCIEven
         case let2M = 0x02
 
         /// Advertiser PHY is LE Coded
+        ///
+        /// When the Controller supports Advertising Coding Selection (Bluetooth 5.4),
+        /// this value indicates LE Coded with S=8 coding.
         case coded = 0x03
+
+        /// Advertiser PHY is LE Coded with S=2 coding.
+        ///
+        /// Only used when the Controller supports Advertising Coding Selection (Bluetooth 5.4).
+        case codedS2 = 0x04
     }
 
     /// Primary_PHY
@@ -208,7 +216,15 @@ public struct HCILEExtendedAdvertisingReport<ReportData: DataContainer>: HCIEven
         case le1M = 0x01
 
         /// Advertiser PHY is LE Coded
+        ///
+        /// When the Controller supports Advertising Coding Selection (Bluetooth 5.4),
+        /// this value indicates LE Coded with S=8 coding.
         case coded = 0x03
+
+        /// Advertiser PHY is LE Coded with S=2 coding.
+        ///
+        /// Only used when the Controller supports Advertising Coding Selection (Bluetooth 5.4).
+        case codedS2 = 0x04
     }
 
     /// Address_Type

--- a/Sources/BluetoothHCI/HCILESetExtendedAdvertisingParameters.swift
+++ b/Sources/BluetoothHCI/HCILESetExtendedAdvertisingParameters.swift
@@ -32,7 +32,7 @@ public extension BluetoothHostControllerInterface {
 @frozen
 public struct HCILESetExtendedAdvertisingParameters: HCICommandParameter {  //HCI_LE_Set_ Extended_ Advertising_ Parameters
 
-    public static let command = HCILowEnergyCommand.setAdvertisingSetRandomAddress  //0x0036
+    public static let command = HCILowEnergyCommand.setExtendedAdvertisingParameters  // 0x0036
 
     /// Used to identify an advertising set
     public let advertisingHandle: UInt8  //Advertising_Handle

--- a/Sources/BluetoothHCI/HCILESetExtendedAdvertisingParametersV2.swift
+++ b/Sources/BluetoothHCI/HCILESetExtendedAdvertisingParametersV2.swift
@@ -1,0 +1,111 @@
+//
+//  HCILESetExtendedAdvertisingParametersV2.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+// MARK: - Method
+
+public extension BluetoothHostControllerInterface {
+
+    /// LE Set Extended Advertising Parameters Command (v2)
+    ///
+    /// The command is used by the Host to set the advertising parameters,
+    /// including the Advertising Coding Selection PHY options (Bluetooth 5.4).
+    func setExtendedAdvertisingParametersV2(
+        _ parameters: HCILESetExtendedAdvertisingParametersV2,
+        timeout: HCICommandTimeout = .default
+    ) async throws -> LowEnergyTxPower {
+
+        let returnParameter = try await deviceRequest(parameters, HCILESetExtendedAdvertisingParametersV2Return.self, timeout: timeout)
+
+        return returnParameter.selectedTxPower
+    }
+}
+
+// MARK: - Command
+
+/// LE Set Extended Advertising Parameters Command (v2)
+///
+/// The command is used by the Host to set the advertising parameters.
+///
+/// Version 2 (Bluetooth 5.4) adds the `Primary_Advertising_PHY_Options` and
+/// `Secondary_Advertising_PHY_Options` parameters, which allow the Host to express
+/// a preference or requirement for the coding scheme (S=2 or S=8) when advertising
+/// on the LE Coded PHY (Advertising Coding Selection).
+@frozen
+public struct HCILESetExtendedAdvertisingParametersV2: HCICommandParameter {
+
+    public static let command = HCILowEnergyCommand.setExtendedAdvertisingParametersV2  // 0x007F
+
+    /// The advertising parameters shared with version 1 of the command.
+    public var parameters: HCILESetExtendedAdvertisingParameters
+
+    /// Primary_Advertising_PHY_Options
+    public var primaryAdvertisingPhyOptions: AdvertisingPhyOptions
+
+    /// Secondary_Advertising_PHY_Options
+    public var secondaryAdvertisingPhyOptions: AdvertisingPhyOptions
+
+    public init(
+        parameters: HCILESetExtendedAdvertisingParameters,
+        primaryAdvertisingPhyOptions: AdvertisingPhyOptions = .noPreference,
+        secondaryAdvertisingPhyOptions: AdvertisingPhyOptions = .noPreference
+    ) {
+
+        self.parameters = parameters
+        self.primaryAdvertisingPhyOptions = primaryAdvertisingPhyOptions
+        self.secondaryAdvertisingPhyOptions = secondaryAdvertisingPhyOptions
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        parameters.append(to: &data)
+        data += primaryAdvertisingPhyOptions.rawValue
+        data += secondaryAdvertisingPhyOptions.rawValue
+    }
+
+    /// Advertising PHY options for the LE Coded PHY coding scheme (Advertising Coding Selection).
+    public enum AdvertisingPhyOptions: UInt8 {
+
+        /// The Host has no preferred or required coding when transmitting on the LE Coded PHY.
+        case noPreference = 0x00
+
+        /// The Host prefers that S=2 coding be used when transmitting on the LE Coded PHY.
+        case preferS2 = 0x01
+
+        /// The Host prefers that S=8 coding be used when transmitting on the LE Coded PHY.
+        case preferS8 = 0x02
+
+        /// The Host requires that S=2 coding be used when transmitting on the LE Coded PHY.
+        case requireS2 = 0x03
+
+        /// The Host requires that S=8 coding be used when transmitting on the LE Coded PHY.
+        case requireS8 = 0x04
+    }
+}
+
+// MARK: - Return Parameter
+
+/// LE Set Extended Advertising Parameters Command (v2)
+@frozen
+public struct HCILESetExtendedAdvertisingParametersV2Return: HCICommandReturnParameter {
+
+    public static let command = HCILowEnergyCommand.setExtendedAdvertisingParametersV2  // 0x007F
+
+    public static let length: Int = 1
+
+    public let selectedTxPower: LowEnergyTxPower
+
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length
+        else { return nil }
+
+        guard let selectedTxPower = LowEnergyTxPower(rawValue: Int8(bitPattern: data[0]))
+        else { return nil }
+
+        self.selectedTxPower = selectedTxPower
+    }
+}

--- a/Sources/BluetoothHCI/LowEnergyCommand.swift
+++ b/Sources/BluetoothHCI/LowEnergyCommand.swift
@@ -242,6 +242,9 @@ public enum HCILowEnergyCommand: UInt16, HCICommand {
 
     /// LE Set Privacy Mode Command
     case setPrivacyMode = 0x004E
+
+    /// LE Set Extended Advertising Parameters Command (v2)
+    case setExtendedAdvertisingParametersV2 = 0x007F
 }
 
 // MARK: - Name
@@ -322,6 +325,7 @@ public extension HCILowEnergyCommand {
         case .readRFPathCompensation: return "LE Read RF Path Compensation Command"
         case .writeRFPathCompensation: return "LE Write RF Path Compensation Command"
         case .setPrivacyMode: return "LE Set Privacy Mode Command"
+        case .setExtendedAdvertisingParametersV2: return "LE Set Extended Advertising Parameters V2"
         case .remoteConnectionParameterRequestReply: return "LE Remote Connection Parameter Request Reply"
         case .remoteConnectionParameterRequestNegativeReply: return "LE Remote Connection Parameter Request Negative Reply Command"
         case .setDataLengthCommand: return "LE Set Data Length Command"

--- a/Sources/BluetoothHCI/LowEnergyFeature.swift
+++ b/Sources/BluetoothHCI/LowEnergyFeature.swift
@@ -68,6 +68,90 @@ public enum LowEnergyFeature: UInt64, BitMaskOption {
     /// Minimum Number of Used Channels Procedure
     case minimumNumberofUsedChannelsProcedure = 0b1_00000000_00000000
 
+    /// Connection CTE Request
+    case connectionCTERequest = 0x0002_0000
+
+    /// Connection CTE Response
+    case connectionCTEResponse = 0x0004_0000
+
+    /// Connectionless CTE Transmitter
+    case connectionlessCTETransmitter = 0x0008_0000
+
+    /// Connectionless CTE Receiver
+    case connectionlessCTEReceiver = 0x0010_0000
+
+    /// Antenna Switching During CTE Transmission (AoD)
+    case antennaSwitchingDuringCTETransmission = 0x0020_0000
+
+    /// Antenna Switching During CTE Reception (AoA)
+    case antennaSwitchingDuringCTEReception = 0x0040_0000
+
+    /// Receiving Constant Tone Extensions
+    case receivingConstantToneExtensions = 0x0080_0000
+
+    /// Periodic Advertising Sync Transfer - Sender
+    case periodicAdvertisingSyncTransferSender = 0x0100_0000
+
+    /// Periodic Advertising Sync Transfer - Recipient
+    case periodicAdvertisingSyncTransferRecipient = 0x0200_0000
+
+    /// Sleep Clock Accuracy Updates
+    case sleepClockAccuracyUpdates = 0x0400_0000
+
+    /// Remote Public Key Validation
+    case remotePublicKeyValidation = 0x0800_0000
+
+    /// Connected Isochronous Stream - Central
+    case connectedIsochronousStreamCentral = 0x1000_0000
+
+    /// Connected Isochronous Stream - Peripheral
+    case connectedIsochronousStreamPeripheral = 0x2000_0000
+
+    /// Isochronous Broadcaster
+    case isochronousBroadcaster = 0x4000_0000
+
+    /// Synchronized Receiver
+    case synchronizedReceiver = 0x8000_0000
+
+    /// Connected Isochronous Stream (Host Support)
+    case connectedIsochronousStreamHostSupport = 0x0001_0000_0000
+
+    /// LE Power Control Request
+    case powerControlRequest = 0x0002_0000_0000
+
+    /// LE Power Change Indication
+    case powerChangeIndication = 0x0004_0000_0000
+
+    /// LE Path Loss Monitoring
+    case pathLossMonitoring = 0x0008_0000_0000
+
+    /// Periodic Advertising ADI support
+    case periodicAdvertisingADISupport = 0x0010_0000_0000
+
+    /// Connection Subrating
+    case connectionSubrating = 0x0020_0000_0000
+
+    /// Connection Subrating (Host Support)
+    case connectionSubratingHostSupport = 0x0040_0000_0000
+
+    /// Channel Classification
+    case channelClassification = 0x0080_0000_0000
+
+    /// Advertising Coding Selection
+    case advertisingCodingSelection = 0x0100_0000_0000
+
+    /// Advertising Coding Selection (Host Support)
+    case advertisingCodingSelectionHostSupport = 0x0200_0000_0000
+
+    /// Decision-Based Advertising Filtering
+    case decisionBasedAdvertisingFiltering = 0x0400_0000_0000
+
+    /// Periodic Advertising with Responses - Advertiser
+    case periodicAdvertisingWithResponsesAdvertiser = 0x0800_0000_0000
+
+    /// Periodic Advertising with Responses - Scanner
+    case periodicAdvertisingWithResponsesScanner = 0x1000_0000_0000
+
     public static let allCases: [LowEnergyFeature] = [
         .encryption,
         .connectionParametersRequestProcedure,
@@ -85,7 +169,35 @@ public enum LowEnergyFeature: UInt64, BitMaskOption {
         .periodicAdvertising,
         .channelSelectionAlgorithm2,
         .powerClass1,
-        .minimumNumberofUsedChannelsProcedure
+        .minimumNumberofUsedChannelsProcedure,
+        .connectionCTERequest,
+        .connectionCTEResponse,
+        .connectionlessCTETransmitter,
+        .connectionlessCTEReceiver,
+        .antennaSwitchingDuringCTETransmission,
+        .antennaSwitchingDuringCTEReception,
+        .receivingConstantToneExtensions,
+        .periodicAdvertisingSyncTransferSender,
+        .periodicAdvertisingSyncTransferRecipient,
+        .sleepClockAccuracyUpdates,
+        .remotePublicKeyValidation,
+        .connectedIsochronousStreamCentral,
+        .connectedIsochronousStreamPeripheral,
+        .isochronousBroadcaster,
+        .synchronizedReceiver,
+        .connectedIsochronousStreamHostSupport,
+        .powerControlRequest,
+        .powerChangeIndication,
+        .pathLossMonitoring,
+        .periodicAdvertisingADISupport,
+        .connectionSubrating,
+        .connectionSubratingHostSupport,
+        .channelClassification,
+        .advertisingCodingSelection,
+        .advertisingCodingSelectionHostSupport,
+        .decisionBasedAdvertisingFiltering,
+        .periodicAdvertisingWithResponsesAdvertiser,
+        .periodicAdvertisingWithResponsesScanner
     ]
 }
 
@@ -145,7 +257,35 @@ internal let featureSet: [LowEnergyFeature: (isValid: Bool, name: String)] = [
     .periodicAdvertising: (false, "LE Periodic Advertising"),
     .channelSelectionAlgorithm2: (true, "Channel Selection Algorithm #2"),
     .powerClass1: (true, "LE Power Class 1"),
-    .minimumNumberofUsedChannelsProcedure: (false, "Minimum Number of Used Channels Procedure")
+    .minimumNumberofUsedChannelsProcedure: (false, "Minimum Number of Used Channels Procedure"),
+    .connectionCTERequest: (true, "Connection CTE Request"),
+    .connectionCTEResponse: (true, "Connection CTE Response"),
+    .connectionlessCTETransmitter: (false, "Connectionless CTE Transmitter"),
+    .connectionlessCTEReceiver: (false, "Connectionless CTE Receiver"),
+    .antennaSwitchingDuringCTETransmission: (false, "Antenna Switching During CTE Transmission (AoD)"),
+    .antennaSwitchingDuringCTEReception: (false, "Antenna Switching During CTE Reception (AoA)"),
+    .receivingConstantToneExtensions: (true, "Receiving Constant Tone Extensions"),
+    .periodicAdvertisingSyncTransferSender: (true, "Periodic Advertising Sync Transfer - Sender"),
+    .periodicAdvertisingSyncTransferRecipient: (true, "Periodic Advertising Sync Transfer - Recipient"),
+    .sleepClockAccuracyUpdates: (true, "Sleep Clock Accuracy Updates"),
+    .remotePublicKeyValidation: (false, "Remote Public Key Validation"),
+    .connectedIsochronousStreamCentral: (true, "Connected Isochronous Stream - Central"),
+    .connectedIsochronousStreamPeripheral: (true, "Connected Isochronous Stream - Peripheral"),
+    .isochronousBroadcaster: (false, "Isochronous Broadcaster"),
+    .synchronizedReceiver: (false, "Synchronized Receiver"),
+    .connectedIsochronousStreamHostSupport: (false, "Connected Isochronous Stream (Host Support)"),
+    .powerControlRequest: (true, "LE Power Control Request"),
+    .powerChangeIndication: (true, "LE Power Change Indication"),
+    .pathLossMonitoring: (false, "LE Path Loss Monitoring"),
+    .periodicAdvertisingADISupport: (false, "Periodic Advertising ADI support"),
+    .connectionSubrating: (true, "Connection Subrating"),
+    .connectionSubratingHostSupport: (false, "Connection Subrating (Host Support)"),
+    .channelClassification: (true, "Channel Classification"),
+    .advertisingCodingSelection: (false, "Advertising Coding Selection"),
+    .advertisingCodingSelectionHostSupport: (false, "Advertising Coding Selection (Host Support)"),
+    .decisionBasedAdvertisingFiltering: (false, "Decision-Based Advertising Filtering"),
+    .periodicAdvertisingWithResponsesAdvertiser: (false, "Periodic Advertising with Responses - Advertiser"),
+    .periodicAdvertisingWithResponsesScanner: (false, "Periodic Advertising with Responses - Scanner")
 ]
 // swiftlint:enable colon
 

--- a/Tests/BluetoothTests/HCITests.swift
+++ b/Tests/BluetoothTests/HCITests.swift
@@ -3247,6 +3247,90 @@ import Foundation
 
         try await hostController.setEventFilter(.clearAll)
     }
+
+    @Test func extendedAdvertisingParametersOpcode() {
+
+        // LE Set Extended Advertising Parameters is 0x0036;
+        // LE Set Advertising Set Random Address is 0x0035
+        #expect(HCILESetExtendedAdvertisingParameters.command == .setExtendedAdvertisingParameters)
+        #expect(HCILESetExtendedAdvertisingParameters.command.rawValue == 0x0036)
+        #expect(HCILESetExtendedAdvertisingParametersV2.command.rawValue == 0x007F)
+    }
+
+    @Test func extendedAdvertisingParametersV2() {
+
+        let parameters = HCILESetExtendedAdvertisingParameters(
+            advertisingHandle: 0x01,
+            advertisingEventProperties: .connectableAdvertising,
+            primaryAdvertising: .init(rawValue: 0xA0...0xA0),
+            primaryAdvertisingChannelMap: .channel37,
+            ownAddressType: .publicDeviceAddress,
+            peerAddressType: .publicDeviceAddress,
+            peerAddress: BluetoothAddress(rawValue: "B0:70:2D:06:D2:AF")!,
+            advertisingFilterPolicy: .processScanFromAllDevices,
+            advertisingTxPower: LowEnergyTxPower(rawValue: 0x14)!,
+            primaryAdvertisingPhy: .le1M,
+            secondaryAdvertisingMaxSkip: 0x00,
+            secondaryAdvertisingPhy: .le1M,
+            advertisingSid: 0x00,
+            scanRequestNotificationEnable: .disabled)
+
+        let v1Data = Data([
+            0x01,  // Advertising_Handle
+            0x01, 0x00,  // Advertising_Event_Properties
+            0xA0, 0x00, 0x00,  // Primary_Advertising_Interval_Min
+            0xA0, 0x00, 0x00,  // Primary_Advertising_Interval_Max
+            0x01,  // Primary_Advertising_Channel_Map
+            0x00,  // Own_Address_Type
+            0x00,  // Peer_Address_Type
+            0xaf, 0xd2, 0x06, 0x2d, 0x70, 0xb0,  // Peer_Address
+            0x00,  // Advertising_Filter_Policy
+            0x14,  // Advertising_Tx_Power
+            0x01,  // Primary_Advertising_PHY
+            0x00,  // Secondary_Advertising_Max_Skip
+            0x01,  // Secondary_Advertising_PHY
+            0x00,  // Advertising_SID
+            0x00  // Scan_Request_Notification_Enable
+        ])
+
+        #expect(Data(parameters) == v1Data)
+
+        // v2 appends the two PHY options octets
+        let v2 = HCILESetExtendedAdvertisingParametersV2(
+            parameters: parameters,
+            primaryAdvertisingPhyOptions: .requireS8,
+            secondaryAdvertisingPhyOptions: .preferS2)
+
+        #expect(Data(v2) == v1Data + Data([0x04, 0x01]))
+
+        // default options
+        let v2Default = HCILESetExtendedAdvertisingParametersV2(parameters: parameters)
+        #expect(Data(v2Default) == v1Data + Data([0x00, 0x00]))
+    }
+
+    @Test func lowEnergyFeatureBits() {
+
+        // Bluetooth 5.4 feature bits (Vol 6 Part B 4.6)
+        #expect(LowEnergyFeature.advertisingCodingSelection.rawValue == 1 << 40)
+        #expect(LowEnergyFeature.advertisingCodingSelectionHostSupport.rawValue == 1 << 41)
+        #expect(LowEnergyFeature.periodicAdvertisingWithResponsesAdvertiser.rawValue == 1 << 43)
+        #expect(LowEnergyFeature.periodicAdvertisingWithResponsesScanner.rawValue == 1 << 44)
+
+        // 5.1 - 5.3 bits
+        #expect(LowEnergyFeature.connectionCTERequest.rawValue == 1 << 17)
+        #expect(LowEnergyFeature.periodicAdvertisingSyncTransferSender.rawValue == 1 << 24)
+        #expect(LowEnergyFeature.connectedIsochronousStreamHostSupport.rawValue == 1 << 32)
+        #expect(LowEnergyFeature.connectionSubrating.rawValue == 1 << 37)
+
+        // every case must have a name entry (would fatalError otherwise)
+        for feature in LowEnergyFeature.allCases {
+            #expect(feature.name.isEmpty == false)
+        }
+
+        // raw values must be unique
+        let rawValues = LowEnergyFeature.allCases.map { $0.rawValue }
+        #expect(Set(rawValues).count == rawValues.count)
+    }
 }
 
 @_silgen_name("swift_bluetooth_parse_event")


### PR DESCRIPTION
Phase 3 of Bluetooth Core 5.4 support: Advertising Coding Selection (CSSA), plus the missing 5.1–5.3 link layer feature bits and another wrong-opcode fix found along the way.

## What changed

- **`HCILESetExtendedAdvertisingParametersV2`** (opcode `0x007F`) — composes the v1 parameters and appends the new `Primary_Advertising_PHY_Options` / `Secondary_Advertising_PHY_Options` octets (`noPreference`/`preferS2`/`preferS8`/`requireS2`/`requireS8`), with return parameter and a `setExtendedAdvertisingParametersV2` convenience method.
- **Extended advertising report** — `PrimaryPHY`/`SecondaryPHY` now accept `0x04` (LE Coded, S=2); `0x03` documented as S=8 under CSSA.
- **`LowEnergyFeature`** — added all missing feature bits 17–44 (CTE, PAST, SCA, CIS/ISO, power control, path loss, subrating, channel classification, CSSA 40/41, DBAF 42, PAwR 43/44) with `allCases` and name-table entries. Bit numbers verified against Zephyr's `hci_types.h`.
- **Bug fix:** `HCILESetExtendedAdvertisingParameters.command` was bound to `.setAdvertisingSetRandomAddress` (0x0035) instead of `.setExtendedAdvertisingParameters` (0x0036) — same defect class as the `setDefaultPhy` fix in #208. The v1 command struct sent the wrong opcode; regression test added.

## Notes for review

- The `isValid` (valid Controller-to-Controller) flags for the new feature bits follow the Vol 6 Part B Table 4.4 pattern (connection procedures = Y; advertising/broadcast/host-support = N) — worth double-checking against the spec table.
- Tests: byte-exact v1/v2 encode vectors, opcode regression checks, feature-bit position checks, uniqueness of raw values, and a sweep asserting every feature case has a name entry (the name lookup would `fatalError` otherwise).

Full suite: 285 tests pass; lint clean.