### PR TITLE
Add Periodic Advertising with Responses (Bluetooth 5.4)

### DIFF
--- a/Sources/BluetoothHCI/HCILEEnhancedConnectionCompleteV2.swift
+++ b/Sources/BluetoothHCI/HCILEEnhancedConnectionCompleteV2.swift
@@ -1,0 +1,132 @@
+//
+//  HCILEEnhancedConnectionCompleteV2.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+/// LE Enhanced Connection Complete Event (v2)
+///
+/// The event indicates to both of the Hosts forming the connection that a new
+/// connection has been created.
+///
+/// Version 2 (Bluetooth 5.4) adds the `Advertising_Handle` and `Sync_Handle`
+/// parameters, which identify the Periodic Advertising with Responses (PAwR)
+/// advertising set and train the connection was created from, or 0xFF / 0xFFFF
+/// if the connection was not created from PAwR.
+@frozen
+public struct HCILEEnhancedConnectionCompleteV2: HCIEventParameter {
+
+    public static let event = LowEnergyEvent.enhancedConnectionCompleteV2  // 0x29
+
+    public static let length: Int = 33
+
+    public let status: HCIStatus
+
+    public let connectionHandle: UInt16
+
+    public let role: LowEnergyRole
+
+    /// Peer Bluetooth address type.
+    public let peerAddressType: LowEnergyAddressType  // Peer_Address_Type
+
+    /// Public Device Address, or Random Device Address, Public Identity Address or
+    /// Random (static) Identity Address of the connected device.
+    public let peerAddress: BluetoothAddress
+
+    /// Resolvable Private Address being used by the local device for this connection.
+    public let localResolvablePrivateAddress: BluetoothAddress
+
+    /// Resolvable Private Address being used by the peer device for this connection.
+    public let peerResolvablePrivateAddress: BluetoothAddress
+
+    /// Connection interval used on this connection.
+    public let interval: LowEnergyConnectionInterval
+
+    /// Peripheral latency for the connection in number of connection events.
+    public let latency: LowEnergyConnectionLatency
+
+    /// Connection supervision timeout.
+    public let supervisionTimeout: LowEnergySupervisionTimeout
+
+    public let masterClockAccuracy: LowEnergyClockAccuracy
+
+    /// The advertising set the connection was created from.
+    ///
+    /// 0xFF if the connection was not created from a PAwR advertising train.
+    public let advertisingHandle: UInt8  // Advertising_Handle
+
+    /// The periodic advertising train the connection was created from.
+    ///
+    /// 0xFFFF if the connection was not created from a PAwR advertising train.
+    public let syncHandle: UInt16  // Sync_Handle
+
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length
+        else { return nil }
+
+        guard let status = HCIStatus(rawValue: data[0])
+        else { return nil }
+
+        let handle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+
+        guard let role = LowEnergyRole(rawValue: data[3])
+        else { return nil }
+
+        guard let peerAddressType = LowEnergyAddressType(rawValue: data[4])
+        else { return nil }
+
+        let peerAddress = BluetoothAddress(
+            littleEndian: BluetoothAddress(
+                bytes: (
+                    data[5],
+                    data[6], data[7],
+                    data[8], data[9],
+                    data[10]
+                )))
+
+        let localResolvablePrivateAddress = BluetoothAddress(
+            littleEndian: BluetoothAddress(
+                bytes: (
+                    data[11],
+                    data[12], data[13],
+                    data[14], data[15],
+                    data[16]
+                )))
+
+        let peerResolvablePrivateAddress = BluetoothAddress(
+            littleEndian: BluetoothAddress(
+                bytes: (
+                    data[17],
+                    data[18], data[19],
+                    data[20], data[21],
+                    data[22]
+                )))
+
+        let interval = LowEnergyConnectionInterval(rawValue: UInt16(littleEndian: UInt16(bytes: (data[23], data[24]))))
+
+        guard let latency = LowEnergyConnectionLatency(rawValue: UInt16(littleEndian: UInt16(bytes: (data[25], data[26]))))
+        else { return nil }
+
+        guard let supervisionTimeout = LowEnergySupervisionTimeout(rawValue: UInt16(littleEndian: UInt16(bytes: (data[27], data[28]))))
+        else { return nil }
+
+        guard let masterClockAccuracy = LowEnergyClockAccuracy(rawValue: data[29])
+        else { return nil }
+
+        self.status = status
+        self.connectionHandle = handle
+        self.role = role
+        self.peerAddressType = peerAddressType
+        self.peerAddress = peerAddress
+        self.localResolvablePrivateAddress = localResolvablePrivateAddress
+        self.peerResolvablePrivateAddress = peerResolvablePrivateAddress
+        self.interval = interval
+        self.latency = latency
+        self.supervisionTimeout = supervisionTimeout
+        self.masterClockAccuracy = masterClockAccuracy
+        self.advertisingHandle = data[30]
+        self.syncHandle = UInt16(littleEndian: UInt16(bytes: (data[31], data[32])))
+    }
+}

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingReportV2.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingReportV2.swift
@@ -1,0 +1,84 @@
+//
+//  HCILEPeriodicAdvertisingReportV2.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// LE Periodic Advertising Report Event (v2)
+///
+/// The event indicates that the Controller has received a Periodic Advertising packet.
+///
+/// Version 2 (Bluetooth 5.4) adds the `Periodic_Event_Counter` and `Subevent`
+/// parameters, indicating the event and subevent of a Periodic Advertising with
+/// Responses (PAwR) train that the packet was received in.
+@frozen
+public struct HCILEPeriodicAdvertisingReportV2<ReportData: DataContainer>: HCIEventParameter {
+
+    public static var event: LowEnergyEvent { .periodicAdvertisingReportV2 }  // 0x25
+
+    /// Minimum length
+    public static var length: Int { 10 }
+
+    public typealias DataStatus = HCILEPeriodicAdvertisingReport<ReportData>.DataStatus
+
+    public let syncHandle: UInt16  // Sync_Handle
+
+    public let txPower: LowEnergyTxPower
+
+    public let rssi: RSSI
+
+    /// Type of Constant Tone Extension in the periodic advertising packet.
+    public let cteType: UInt8  // CTE_Type
+
+    /// The value of the periodic event counter of the packet.
+    public let periodicEventCounter: UInt16  // Periodic_Event_Counter
+
+    /// The subevent number of the packet, or 0xFF if received in a periodic
+    /// advertising train without responses.
+    public let subevent: UInt8  // Subevent
+
+    public let dataStatus: DataStatus
+
+    public let data: ReportData
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count >= Self.length
+        else { return nil }
+
+        self.syncHandle = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+
+        guard let txPower = LowEnergyTxPower(rawValue: Int8(bitPattern: data[2]))
+        else { return nil }
+        self.txPower = txPower
+
+        guard let rssi = RSSI(rawValue: Int8(bitPattern: data[3]))
+        else { return nil }
+        self.rssi = rssi
+
+        self.cteType = data[4]
+
+        self.periodicEventCounter = UInt16(littleEndian: UInt16(bytes: (data[5], data[6])))
+
+        self.subevent = data[7]
+
+        guard let dataStatus = DataStatus(rawValue: data[8])
+        else { return nil }
+        self.dataStatus = dataStatus
+
+        let dataLength = Int(data[9])
+
+        guard data.count >= Self.length + dataLength
+        else { return nil }
+
+        if dataLength > 0 {
+            self.data = ReportData(data[10..<10 + dataLength])
+        } else {
+            self.data = ReportData()
+        }
+    }
+}

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingResponseReport.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingResponseReport.swift
@@ -1,0 +1,175 @@
+//
+//  HCILEPeriodicAdvertisingResponseReport.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+/// LE Periodic Advertising Response Report Event
+///
+/// The Controller sends this event to the Broadcaster's Host to report the responses
+/// it received in the response slots of a Periodic Advertising with Responses (PAwR)
+/// subevent (Bluetooth 5.4).
+@frozen
+public struct HCILEPeriodicAdvertisingResponseReport<ResponseData: DataContainer>: HCIEventParameter, Equatable, Hashable, Sendable {
+
+    public static var event: LowEnergyEvent { .periodicAdvertisingResponseReport }  // 0x28
+
+    /// Minimum length (no responses)
+    public static var length: Int { 4 }
+
+    /// Used to identify an advertising set
+    public let advertisingHandle: UInt8  // Advertising_Handle
+
+    /// The subevent the responses were received in.
+    public let subevent: UInt8  // Subevent
+
+    /// Whether the subevent advertising packet was transmitted.
+    public let txStatus: TxStatus  // Tx_Status
+
+    /// The responses received in the response slots.
+    public let responses: [Response]
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count >= Self.length
+        else { return nil }
+
+        self.advertisingHandle = data[0]
+        self.subevent = data[1]
+
+        guard let txStatus = TxStatus(rawValue: data[2])
+        else { return nil }
+        self.txStatus = txStatus
+
+        let responseCount = Int(data[3])
+
+        var responses = [Response]()
+        responses.reserveCapacity(responseCount)
+
+        var offset = 4
+        for _ in 0..<responseCount {
+
+            guard data.count >= offset + Response.minimumLength
+            else { return nil }
+
+            // 0x7F indicates the value is not available
+            let txPowerRawValue = Int8(bitPattern: data[offset])
+            let txPower: LowEnergyTxPower?
+            if txPowerRawValue == 0x7F {
+                txPower = nil
+            } else {
+                guard let value = LowEnergyTxPower(rawValue: txPowerRawValue)
+                else { return nil }
+                txPower = value
+            }
+
+            let rssiRawValue = Int8(bitPattern: data[offset + 1])
+            let rssi: RSSI?
+            if rssiRawValue == 0x7F {
+                rssi = nil
+            } else {
+                guard let value = RSSI(rawValue: rssiRawValue)
+                else { return nil }
+                rssi = value
+            }
+
+            let cteType = data[offset + 2]
+            let responseSlot = data[offset + 3]
+
+            guard let dataStatus = DataStatus(rawValue: data[offset + 4])
+            else { return nil }
+
+            let dataLength = Int(data[offset + 5])
+            offset += Response.minimumLength
+
+            guard data.count >= offset + dataLength
+            else { return nil }
+
+            let responseData: ResponseData
+            if dataLength > 0 {
+                responseData = ResponseData(data[offset..<offset + dataLength])
+            } else {
+                responseData = ResponseData()
+            }
+            offset += dataLength
+
+            responses.append(
+                Response(
+                    txPower: txPower,
+                    rssi: rssi,
+                    cteType: cteType,
+                    responseSlot: responseSlot,
+                    dataStatus: dataStatus,
+                    data: responseData
+                ))
+        }
+
+        self.responses = responses
+    }
+
+    /// Whether the subevent indication was transmitted.
+    public enum TxStatus: UInt8, Sendable {
+
+        /// AUX_SYNC_SUBEVENT_IND packet was transmitted.
+        case transmitted = 0x00
+
+        /// AUX_SYNC_SUBEVENT_IND packet was not transmitted.
+        case notTransmitted = 0x01
+    }
+
+    /// Data status of a response.
+    public enum DataStatus: UInt8, Sendable {
+
+        /// Data complete
+        case complete = 0x00
+
+        /// Data incomplete, more data to come
+        case incomplete = 0x01
+
+        /// Failed to receive an AUX_SYNC_SUBEVENT_RSP PDU in this response slot
+        case failed = 0xFF
+    }
+
+    /// A response received in a response slot.
+    public struct Response: Equatable, Hashable, Sendable {
+
+        internal static var minimumLength: Int { 6 }
+
+        /// Transmit power of the response, or `nil` if not available.
+        public let txPower: LowEnergyTxPower?  // Tx_Power
+
+        /// RSSI of the response, or `nil` if not available.
+        public let rssi: RSSI?  // RSSI
+
+        /// Type of Constant Tone Extension in the response.
+        public let cteType: UInt8  // CTE_Type
+
+        /// The response slot the response was received in.
+        public let responseSlot: UInt8  // Response_Slot
+
+        /// Data status of the response.
+        public let dataStatus: DataStatus  // Data_Status
+
+        /// Response data.
+        public let data: ResponseData  // Data
+
+        public init(
+            txPower: LowEnergyTxPower?,
+            rssi: RSSI?,
+            cteType: UInt8,
+            responseSlot: UInt8,
+            dataStatus: DataStatus,
+            data: ResponseData
+        ) {
+
+            self.txPower = txPower
+            self.rssi = rssi
+            self.cteType = cteType
+            self.responseSlot = responseSlot
+            self.dataStatus = dataStatus
+            self.data = data
+        }
+    }
+}

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSubeventDataRequest.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSubeventDataRequest.swift
@@ -1,0 +1,40 @@
+//
+//  HCILEPeriodicAdvertisingSubeventDataRequest.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+/// LE Periodic Advertising Subevent Data Request Event
+///
+/// The Controller sends this event to the Host to request data for one or more
+/// subevents of a Periodic Advertising with Responses (PAwR) advertising train
+/// (Bluetooth 5.4). The Host replies with one or more LE Set Periodic Advertising
+/// Subevent Data commands.
+@frozen
+public struct HCILEPeriodicAdvertisingSubeventDataRequest: HCIEventParameter, Equatable, Hashable, Sendable {
+
+    public static var event: LowEnergyEvent { .periodicAdvertisingSubeventDataRequest }  // 0x27
+
+    public static var length: Int { 3 }
+
+    /// Used to identify an advertising set
+    public let advertisingHandle: UInt8  // Advertising_Handle
+
+    /// The first subevent that data is requested for.
+    public let subeventStart: UInt8  // Subevent_Start
+
+    /// The number of subevents that data is requested for.
+    public let subeventDataCount: UInt8  // Subevent_Data_Count
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count == Self.length
+        else { return nil }
+
+        self.advertisingHandle = data[0]
+        self.subeventStart = data[1]
+        self.subeventDataCount = data[2]
+    }
+}

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncEstablishedV2.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncEstablishedV2.swift
@@ -1,0 +1,105 @@
+//
+//  HCILEPeriodicAdvertisingSyncEstablishedV2.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+/// LE Periodic Advertising Sync Established Event (v2)
+///
+/// The event indicates that the Controller has received the first periodic advertising
+/// packet from an advertiser after the LE_Periodic_Advertising_Create_Sync command has
+/// been sent to the Controller.
+///
+/// Version 2 (Bluetooth 5.4) adds the `Num_Subevents`, `Subevent_Interval`,
+/// `Response_Slot_Delay`, and `Response_Slot_Spacing` parameters describing the
+/// Periodic Advertising with Responses (PAwR) train, or zero if the periodic
+/// advertising train does not use responses.
+@frozen
+public struct HCILEPeriodicAdvertisingSyncEstablishedV2: HCIEventParameter {
+
+    public static let event = LowEnergyEvent.periodicAdvertisingSyncEstablishedV2  // 0x24
+
+    public static let length = 19
+
+    public typealias AdvertiserPhy = HCILEPeriodicAdvertisingSyncEstablished.AdvertiserPhy
+
+    public typealias PeriodicAdvertisingInterval = HCILEPeriodicAdvertisingSyncEstablished.PeriodicAdvertisingInterval
+
+    public let status: HCIStatus
+
+    /// Sync_Handle to be used to identify the periodic advertiser
+    /// Range: 0x0000-0x0EFF
+    public let syncHandle: UInt16  // Sync_Handle
+
+    /// Value of the Advertising SID subfield in the ADI field of the PDU
+    public let advertisingSID: UInt8
+
+    public let advertiserAddressType: LowEnergyAddressType
+
+    public let advertiserAddress: BluetoothAddress
+
+    public let advertiserPHY: AdvertiserPhy
+
+    public let periodicAdvertisingInterval: PeriodicAdvertisingInterval
+
+    public let advertiserClockAccuracy: LowEnergyClockAccuracy
+
+    /// Number of subevents (0 if the periodic advertising train has no responses).
+    public let numberOfSubevents: UInt8  // Num_Subevents
+
+    /// Time between the subevents of PAwR.
+    ///
+    /// Time = N × 1.25 ms
+    public let subeventInterval: UInt8  // Subevent_Interval
+
+    /// Time between the advertising packet in a subevent and the first response slot.
+    ///
+    /// Time = N × 1.25 ms
+    public let responseSlotDelay: UInt8  // Response_Slot_Delay
+
+    /// Time between response slots.
+    ///
+    /// Time = N × 0.125 ms
+    public let responseSlotSpacing: UInt8  // Response_Slot_Spacing
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count == Self.length
+        else { return nil }
+
+        guard let status = HCIStatus(rawValue: data[0])
+        else { return nil }
+
+        let syncHandle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+
+        let advertisingSID = data[3]
+
+        guard let advertiserAddressType = LowEnergyAddressType(rawValue: data[4])
+        else { return nil }
+
+        let advertiserAddress = BluetoothAddress(littleEndian: BluetoothAddress(bytes: (data[5], data[6], data[7], data[8], data[9], data[10])))
+
+        guard let advertiserPHY = AdvertiserPhy(rawValue: data[11])
+        else { return nil }
+
+        let periodicAdvertisingInterval = PeriodicAdvertisingInterval(rawValue: UInt16(littleEndian: UInt16(bytes: (data[12], data[13]))))
+
+        guard let advertiserClockAccuracy = LowEnergyClockAccuracy(rawValue: data[14])
+        else { return nil }
+
+        self.status = status
+        self.syncHandle = syncHandle
+        self.advertisingSID = advertisingSID
+        self.advertiserAddressType = advertiserAddressType
+        self.advertiserAddress = advertiserAddress
+        self.advertiserPHY = advertiserPHY
+        self.periodicAdvertisingInterval = periodicAdvertisingInterval
+        self.advertiserClockAccuracy = advertiserClockAccuracy
+        self.numberOfSubevents = data[15]
+        self.subeventInterval = data[16]
+        self.responseSlotDelay = data[17]
+        self.responseSlotSpacing = data[18]
+    }
+}

--- a/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncTransferReceivedV2.swift
+++ b/Sources/BluetoothHCI/HCILEPeriodicAdvertisingSyncTransferReceivedV2.swift
@@ -1,0 +1,119 @@
+//
+//  HCILEPeriodicAdvertisingSyncTransferReceivedV2.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+/// LE Periodic Advertising Sync Transfer Received Event (v2)
+///
+/// The event is used by the Controller to report that it has received periodic
+/// advertising synchronization information from the connected device identified by
+/// the Connection_Handle and either successfully synchronized to the periodic
+/// advertising train or timed out while attempting to synchronize.
+///
+/// Version 2 (Bluetooth 5.4) adds the `Num_Subevents`, `Subevent_Interval`,
+/// `Response_Slot_Delay`, and `Response_Slot_Spacing` parameters describing the
+/// Periodic Advertising with Responses (PAwR) train, or zero if the periodic
+/// advertising train does not use responses.
+@frozen
+public struct HCILEPeriodicAdvertisingSyncTransferReceivedV2: HCIEventParameter {
+
+    public static let event = LowEnergyEvent.periodicAdvertisingSyncTransferReceivedV2  // 0x26
+
+    public static let length = 23
+
+    public typealias AdvertiserPhy = HCILEPeriodicAdvertisingSyncEstablished.AdvertiserPhy
+
+    public typealias PeriodicAdvertisingInterval = HCILEPeriodicAdvertisingSyncEstablished.PeriodicAdvertisingInterval
+
+    public let status: HCIStatus
+
+    /// Connection handle of the connection the synchronization information
+    /// was received over.
+    public let connectionHandle: UInt16  // Connection_Handle
+
+    /// A value provided by the peer device.
+    public let serviceData: UInt16  // Service_Data
+
+    /// Sync_Handle to be used to identify the periodic advertiser
+    /// Range: 0x0000-0x0EFF
+    public let syncHandle: UInt16  // Sync_Handle
+
+    /// Value of the Advertising SID subfield in the ADI field of the PDU
+    public let advertisingSID: UInt8
+
+    public let advertiserAddressType: LowEnergyAddressType
+
+    public let advertiserAddress: BluetoothAddress
+
+    public let advertiserPHY: AdvertiserPhy
+
+    public let periodicAdvertisingInterval: PeriodicAdvertisingInterval
+
+    public let advertiserClockAccuracy: LowEnergyClockAccuracy
+
+    /// Number of subevents (0 if the periodic advertising train has no responses).
+    public let numberOfSubevents: UInt8  // Num_Subevents
+
+    /// Time between the subevents of PAwR.
+    ///
+    /// Time = N × 1.25 ms
+    public let subeventInterval: UInt8  // Subevent_Interval
+
+    /// Time between the advertising packet in a subevent and the first response slot.
+    ///
+    /// Time = N × 1.25 ms
+    public let responseSlotDelay: UInt8  // Response_Slot_Delay
+
+    /// Time between response slots.
+    ///
+    /// Time = N × 0.125 ms
+    public let responseSlotSpacing: UInt8  // Response_Slot_Spacing
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count == Self.length
+        else { return nil }
+
+        guard let status = HCIStatus(rawValue: data[0])
+        else { return nil }
+
+        let connectionHandle = UInt16(littleEndian: UInt16(bytes: (data[1], data[2])))
+
+        let serviceData = UInt16(littleEndian: UInt16(bytes: (data[3], data[4])))
+
+        let syncHandle = UInt16(littleEndian: UInt16(bytes: (data[5], data[6])))
+
+        let advertisingSID = data[7]
+
+        guard let advertiserAddressType = LowEnergyAddressType(rawValue: data[8])
+        else { return nil }
+
+        let advertiserAddress = BluetoothAddress(littleEndian: BluetoothAddress(bytes: (data[9], data[10], data[11], data[12], data[13], data[14])))
+
+        guard let advertiserPHY = AdvertiserPhy(rawValue: data[15])
+        else { return nil }
+
+        let periodicAdvertisingInterval = PeriodicAdvertisingInterval(rawValue: UInt16(littleEndian: UInt16(bytes: (data[16], data[17]))))
+
+        guard let advertiserClockAccuracy = LowEnergyClockAccuracy(rawValue: data[18])
+        else { return nil }
+
+        self.status = status
+        self.connectionHandle = connectionHandle
+        self.serviceData = serviceData
+        self.syncHandle = syncHandle
+        self.advertisingSID = advertisingSID
+        self.advertiserAddressType = advertiserAddressType
+        self.advertiserAddress = advertiserAddress
+        self.advertiserPHY = advertiserPHY
+        self.periodicAdvertisingInterval = periodicAdvertisingInterval
+        self.advertiserClockAccuracy = advertiserClockAccuracy
+        self.numberOfSubevents = data[19]
+        self.subeventInterval = data[20]
+        self.responseSlotDelay = data[21]
+        self.responseSlotSpacing = data[22]
+    }
+}

--- a/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingParametersV2.swift
+++ b/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingParametersV2.swift
@@ -1,0 +1,141 @@
+//
+//  HCILESetPeriodicAdvertisingParametersV2.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+// MARK: - Method
+
+public extension BluetoothHostControllerInterface {
+
+    /// LE Set Periodic Advertising Parameters Command (v2)
+    ///
+    /// The command is used by the Host to set the parameters for periodic advertising,
+    /// including the subevent parameters required for Periodic Advertising with
+    /// Responses (Bluetooth 5.4).
+    func setPeriodicAdvertisingParametersV2(
+        _ parameters: HCILESetPeriodicAdvertisingParametersV2,
+        timeout: HCICommandTimeout = .default
+    ) async throws -> UInt8 {
+
+        let returnParameter = try await deviceRequest(parameters, HCILESetPeriodicAdvertisingParametersV2Return.self, timeout: timeout)
+
+        return returnParameter.advertisingHandle
+    }
+}
+
+// MARK: - Command
+
+/// LE Set Periodic Advertising Parameters Command (v2)
+///
+/// The command is used by the Host to set the parameters for periodic advertising.
+///
+/// Version 2 (Bluetooth 5.4) adds the `Num_Subevents`, `Subevent_Interval`,
+/// `Response_Slot_Delay`, `Response_Slot_Spacing`, and `Num_Response_Slots`
+/// parameters, which configure the Controller for Periodic Advertising with
+/// Responses (PAwR).
+@frozen
+public struct HCILESetPeriodicAdvertisingParametersV2: HCICommandParameter {
+
+    public static let command = HCILowEnergyCommand.setPeriodicAdvertisingParametersV2  // 0x0086
+
+    public typealias PeriodicAdvertisingInterval = HCILESetPeriodicAdvertisingParameters.PeriodicAdvertisingInterval
+
+    public typealias AdvertisingEventProperties = HCILESetPeriodicAdvertisingParameters.AdvertisingEventProperties
+
+    /// Used to identify an advertising set
+    public var advertisingHandle: UInt8  // Advertising_Handle
+
+    public var periodicAdvertisingInterval: PeriodicAdvertisingInterval
+
+    public var advertisingEventProperties: AdvertisingEventProperties
+
+    /// Number of subevents per PAwR event.
+    ///
+    /// A value of 0 disables Periodic Advertising with Responses.
+    public var numberOfSubevents: UInt8  // Num_Subevents
+
+    /// Time between the subevents of PAwR.
+    ///
+    /// Time = N × 1.25 ms
+    public var subeventInterval: UInt8  // Subevent_Interval
+
+    /// Time between the advertising packet in a subevent and the first response slot.
+    ///
+    /// Time = N × 1.25 ms
+    public var responseSlotDelay: UInt8  // Response_Slot_Delay
+
+    /// Time between response slots.
+    ///
+    /// Time = N × 0.125 ms
+    public var responseSlotSpacing: UInt8  // Response_Slot_Spacing
+
+    /// Number of subevent response slots.
+    public var numberOfResponseSlots: UInt8  // Num_Response_Slots
+
+    public init(
+        advertisingHandle: UInt8,
+        periodicAdvertisingInterval: PeriodicAdvertisingInterval,
+        advertisingEventProperties: AdvertisingEventProperties,
+        numberOfSubevents: UInt8 = 0,
+        subeventInterval: UInt8 = 0,
+        responseSlotDelay: UInt8 = 0,
+        responseSlotSpacing: UInt8 = 0,
+        numberOfResponseSlots: UInt8 = 0
+    ) {
+
+        self.advertisingHandle = advertisingHandle
+        self.periodicAdvertisingInterval = periodicAdvertisingInterval
+        self.advertisingEventProperties = advertisingEventProperties
+        self.numberOfSubevents = numberOfSubevents
+        self.subeventInterval = subeventInterval
+        self.responseSlotDelay = responseSlotDelay
+        self.responseSlotSpacing = responseSlotSpacing
+        self.numberOfResponseSlots = numberOfResponseSlots
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        let intervalMinBytes = periodicAdvertisingInterval.rawValue.lowerBound.littleEndian.bytes
+        let intervalMaxBytes = periodicAdvertisingInterval.rawValue.upperBound.littleEndian.bytes
+        let propertiesBytes = advertisingEventProperties.rawValue.littleEndian.bytes
+
+        data += [
+            advertisingHandle,
+            intervalMinBytes.0,
+            intervalMinBytes.1,
+            intervalMaxBytes.0,
+            intervalMaxBytes.1,
+            propertiesBytes.0,
+            propertiesBytes.1,
+            numberOfSubevents,
+            subeventInterval,
+            responseSlotDelay,
+            responseSlotSpacing,
+            numberOfResponseSlots
+        ]
+    }
+}
+
+// MARK: - Return Parameter
+
+/// LE Set Periodic Advertising Parameters Command (v2)
+@frozen
+public struct HCILESetPeriodicAdvertisingParametersV2Return: HCICommandReturnParameter {
+
+    public static let command = HCILowEnergyCommand.setPeriodicAdvertisingParametersV2  // 0x0086
+
+    public static let length: Int = 1
+
+    /// Used to identify an advertising set
+    public let advertisingHandle: UInt8
+
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length
+        else { return nil }
+
+        self.advertisingHandle = data[0]
+    }
+}

--- a/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingResponseData.swift
+++ b/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingResponseData.swift
@@ -1,0 +1,115 @@
+//
+//  HCILESetPeriodicAdvertisingResponseData.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+// MARK: - Method
+
+public extension BluetoothHostControllerInterface {
+
+    /// LE Set Periodic Advertising Response Data Command
+    ///
+    /// Used by the Host to set the data for a response slot in a specific subevent
+    /// of a Periodic Advertising with Responses (PAwR) advertising train
+    /// (Bluetooth 5.4).
+    func lowEnergySetPeriodicAdvertisingResponseData<ResponseData: DataContainer>(
+        _ parameters: HCILESetPeriodicAdvertisingResponseData<ResponseData>,
+        timeout: HCICommandTimeout = .default
+    ) async throws -> UInt16 {
+
+        let returnParameter = try await deviceRequest(parameters, HCILESetPeriodicAdvertisingResponseDataReturn.self, timeout: timeout)
+
+        return returnParameter.syncHandle
+    }
+}
+
+// MARK: - Command
+
+/// LE Set Periodic Advertising Response Data Command
+///
+/// Used by the Host to set the data for a response slot in a specific subevent of the
+/// PAwR advertising train identified by the Sync_Handle. The data for a response slot
+/// will be transmitted only once.
+@frozen
+public struct HCILESetPeriodicAdvertisingResponseData<ResponseData: DataContainer>: HCICommandParameter {
+
+    public static var command: HCILowEnergyCommand { .setPeriodicAdvertisingResponseData }  // 0x0083
+
+    /// Identifies the PAwR advertising train.
+    public var syncHandle: UInt16  // Sync_Handle
+
+    /// The periodic event counter of the request the response is sent to.
+    public var requestEvent: UInt16  // Request_Event
+
+    /// The subevent of the request the response is sent to.
+    public var requestSubevent: UInt8  // Request_Subevent
+
+    /// The subevent that the response shall be sent in.
+    public var responseSubevent: UInt8  // Response_Subevent
+
+    /// The response slot that the response shall be sent in.
+    public var responseSlot: UInt8  // Response_Slot
+
+    /// The response data.
+    public var responseData: ResponseData  // Response_Data
+
+    public init(
+        syncHandle: UInt16,
+        requestEvent: UInt16,
+        requestSubevent: UInt8,
+        responseSubevent: UInt8,
+        responseSlot: UInt8,
+        responseData: ResponseData
+    ) {
+
+        self.syncHandle = syncHandle
+        self.requestEvent = requestEvent
+        self.requestSubevent = requestSubevent
+        self.responseSubevent = responseSubevent
+        self.responseSlot = responseSlot
+        self.responseData = responseData
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        let syncHandleBytes = syncHandle.littleEndian.bytes
+        let requestEventBytes = requestEvent.littleEndian.bytes
+
+        data += [
+            syncHandleBytes.0,
+            syncHandleBytes.1,
+            requestEventBytes.0,
+            requestEventBytes.1,
+            requestSubevent,
+            responseSubevent,
+            responseSlot,
+            UInt8(responseData.count)
+        ]
+
+        data += responseData
+    }
+}
+
+// MARK: - Return Parameter
+
+/// LE Set Periodic Advertising Response Data Command
+@frozen
+public struct HCILESetPeriodicAdvertisingResponseDataReturn: HCICommandReturnParameter {
+
+    public static let command = HCILowEnergyCommand.setPeriodicAdvertisingResponseData  // 0x0083
+
+    public static let length: Int = 2
+
+    /// Identifies the PAwR advertising train.
+    public let syncHandle: UInt16
+
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length
+        else { return nil }
+
+        self.syncHandle = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+    }
+}

--- a/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingSubeventData.swift
+++ b/Sources/BluetoothHCI/HCILESetPeriodicAdvertisingSubeventData.swift
@@ -1,0 +1,124 @@
+//
+//  HCILESetPeriodicAdvertisingSubeventData.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+// MARK: - Method
+
+public extension BluetoothHostControllerInterface {
+
+    /// LE Set Periodic Advertising Subevent Data Command
+    ///
+    /// Used by the Host to set the data for one or more subevents of Periodic
+    /// Advertising with Responses (Bluetooth 5.4), in reply to an
+    /// LE Periodic Advertising Subevent Data Request event.
+    func lowEnergySetPeriodicAdvertisingSubeventData(
+        advertisingHandle: UInt8,
+        subevents: [HCILESetPeriodicAdvertisingSubeventData<[UInt8]>.Subevent],
+        timeout: HCICommandTimeout = .default
+    ) async throws -> UInt8 {
+
+        let parameters = HCILESetPeriodicAdvertisingSubeventData(
+            advertisingHandle: advertisingHandle,
+            subevents: subevents)
+
+        let returnParameter = try await deviceRequest(parameters, HCILESetPeriodicAdvertisingSubeventDataReturn.self, timeout: timeout)
+
+        return returnParameter.advertisingHandle
+    }
+}
+
+// MARK: - Command
+
+/// LE Set Periodic Advertising Subevent Data Command
+///
+/// Used by the Host to set the data for one or more subevents of Periodic Advertising
+/// with Responses (PAwR) in reply to an LE Periodic Advertising Subevent Data Request
+/// event. The data for a subevent will be transmitted only once.
+@frozen
+public struct HCILESetPeriodicAdvertisingSubeventData<SubeventData: DataContainer>: HCICommandParameter {
+
+    public static var command: HCILowEnergyCommand { .setPeriodicAdvertisingSubeventData }  // 0x0082
+
+    /// Used to identify an advertising set
+    public var advertisingHandle: UInt8  // Advertising_Handle
+
+    /// Data for each subevent (maximum of 15 per command).
+    public var subevents: [Subevent]
+
+    public init(
+        advertisingHandle: UInt8,
+        subevents: [Subevent]
+    ) {
+
+        self.advertisingHandle = advertisingHandle
+        self.subevents = subevents
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        data += advertisingHandle
+        data += UInt8(subevents.count)
+
+        for subevent in subevents {
+            data += subevent.subevent
+            data += subevent.responseSlotStart
+            data += subevent.responseSlotCount
+            data += UInt8(subevent.data.count)
+            data += subevent.data
+        }
+    }
+
+    /// Data for a single PAwR subevent.
+    public struct Subevent: Equatable, Hashable, Sendable {
+
+        /// The subevent index of the data contained in this command.
+        public var subevent: UInt8  // Subevent
+
+        /// The first response slot to be used in this subevent.
+        public var responseSlotStart: UInt8  // Response_Slot_Start
+
+        /// The number of response slots to be used.
+        public var responseSlotCount: UInt8  // Response_Slot_Count
+
+        /// Advertising data to be transmitted in the subevent.
+        public var data: SubeventData  // Subevent_Data
+
+        public init(
+            subevent: UInt8,
+            responseSlotStart: UInt8,
+            responseSlotCount: UInt8,
+            data: SubeventData
+        ) {
+
+            self.subevent = subevent
+            self.responseSlotStart = responseSlotStart
+            self.responseSlotCount = responseSlotCount
+            self.data = data
+        }
+    }
+}
+
+// MARK: - Return Parameter
+
+/// LE Set Periodic Advertising Subevent Data Command
+@frozen
+public struct HCILESetPeriodicAdvertisingSubeventDataReturn: HCICommandReturnParameter {
+
+    public static let command = HCILowEnergyCommand.setPeriodicAdvertisingSubeventData  // 0x0082
+
+    public static let length: Int = 1
+
+    /// Used to identify an advertising set
+    public let advertisingHandle: UInt8
+
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length
+        else { return nil }
+
+        self.advertisingHandle = data[0]
+    }
+}

--- a/Sources/BluetoothHCI/HCILESetPeriodicSyncSubevent.swift
+++ b/Sources/BluetoothHCI/HCILESetPeriodicSyncSubevent.swift
@@ -1,0 +1,118 @@
+//
+//  HCILESetPeriodicSyncSubevent.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+// MARK: - Method
+
+public extension BluetoothHostControllerInterface {
+
+    /// LE Set Periodic Sync Subevent Command
+    ///
+    /// Used by the Host to instruct the Controller to synchronize with a subset of the
+    /// subevents within a Periodic Advertising with Responses (PAwR) advertising train
+    /// (Bluetooth 5.4).
+    func lowEnergySetPeriodicSyncSubevent(
+        syncHandle: UInt16,
+        periodicAdvertisingProperties: HCILESetPeriodicSyncSubevent.PeriodicAdvertisingProperties,
+        subevents: [UInt8],
+        timeout: HCICommandTimeout = .default
+    ) async throws -> UInt16 {
+
+        let parameters = HCILESetPeriodicSyncSubevent(
+            syncHandle: syncHandle,
+            periodicAdvertisingProperties: periodicAdvertisingProperties,
+            subevents: subevents)
+
+        let returnParameter = try await deviceRequest(parameters, HCILESetPeriodicSyncSubeventReturn.self, timeout: timeout)
+
+        return returnParameter.syncHandle
+    }
+}
+
+// MARK: - Command
+
+/// LE Set Periodic Sync Subevent Command
+///
+/// Used by the Host to instruct the Controller to synchronize with a subset of the
+/// subevents within a PAwR advertising train identified by the Sync_Handle, listen
+/// for packets sent by the peer device in these subevents, and send subevent
+/// responses.
+@frozen
+public struct HCILESetPeriodicSyncSubevent: HCICommandParameter {
+
+    public static let command = HCILowEnergyCommand.setPeriodicSyncSubevent  // 0x0084
+
+    /// Identifies the PAwR advertising train.
+    public var syncHandle: UInt16  // Sync_Handle
+
+    /// Properties of the advertisement.
+    public var periodicAdvertisingProperties: PeriodicAdvertisingProperties  // Periodic_Advertising_Properties
+
+    /// The subevents to synchronize with.
+    public var subevents: [UInt8]  // Subevent
+
+    public init(
+        syncHandle: UInt16,
+        periodicAdvertisingProperties: PeriodicAdvertisingProperties = [],
+        subevents: [UInt8]
+    ) {
+
+        self.syncHandle = syncHandle
+        self.periodicAdvertisingProperties = periodicAdvertisingProperties
+        self.subevents = subevents
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        let syncHandleBytes = syncHandle.littleEndian.bytes
+        let propertiesBytes = periodicAdvertisingProperties.rawValue.littleEndian.bytes
+
+        data += [
+            syncHandleBytes.0,
+            syncHandleBytes.1,
+            propertiesBytes.0,
+            propertiesBytes.1,
+            UInt8(subevents.count)
+        ]
+
+        data += subevents
+    }
+
+    /// Properties of the advertisement.
+    public struct PeriodicAdvertisingProperties: OptionSet, Equatable, Hashable, Sendable {
+
+        public let rawValue: UInt16
+
+        public init(rawValue: UInt16) {
+            self.rawValue = rawValue
+        }
+
+        /// Include TxPower in the advertising PDU.
+        public static var includeTxPower: PeriodicAdvertisingProperties { PeriodicAdvertisingProperties(rawValue: 0b100000) }
+    }
+}
+
+// MARK: - Return Parameter
+
+/// LE Set Periodic Sync Subevent Command
+@frozen
+public struct HCILESetPeriodicSyncSubeventReturn: HCICommandReturnParameter {
+
+    public static let command = HCILowEnergyCommand.setPeriodicSyncSubevent  // 0x0084
+
+    public static let length: Int = 2
+
+    /// Identifies the PAwR advertising train.
+    public let syncHandle: UInt16
+
+    public init?<Data: DataContainer>(data: Data) {
+        guard data.count == Self.length
+        else { return nil }
+
+        self.syncHandle = UInt16(littleEndian: UInt16(bytes: (data[0], data[1])))
+    }
+}

--- a/Sources/BluetoothHCI/LowEnergyCommand.swift
+++ b/Sources/BluetoothHCI/LowEnergyCommand.swift
@@ -245,6 +245,18 @@ public enum HCILowEnergyCommand: UInt16, HCICommand {
 
     /// LE Set Extended Advertising Parameters Command (v2)
     case setExtendedAdvertisingParametersV2 = 0x007F
+
+    /// LE Set Periodic Advertising Subevent Data Command
+    case setPeriodicAdvertisingSubeventData = 0x0082
+
+    /// LE Set Periodic Advertising Response Data Command
+    case setPeriodicAdvertisingResponseData = 0x0083
+
+    /// LE Set Periodic Sync Subevent Command
+    case setPeriodicSyncSubevent = 0x0084
+
+    /// LE Set Periodic Advertising Parameters Command (v2)
+    case setPeriodicAdvertisingParametersV2 = 0x0086
 }
 
 // MARK: - Name
@@ -326,6 +338,10 @@ public extension HCILowEnergyCommand {
         case .writeRFPathCompensation: return "LE Write RF Path Compensation Command"
         case .setPrivacyMode: return "LE Set Privacy Mode Command"
         case .setExtendedAdvertisingParametersV2: return "LE Set Extended Advertising Parameters V2"
+        case .setPeriodicAdvertisingSubeventData: return "LE Set Periodic Advertising Subevent Data"
+        case .setPeriodicAdvertisingResponseData: return "LE Set Periodic Advertising Response Data"
+        case .setPeriodicSyncSubevent: return "LE Set Periodic Sync Subevent"
+        case .setPeriodicAdvertisingParametersV2: return "LE Set Periodic Advertising Parameters V2"
         case .remoteConnectionParameterRequestReply: return "LE Remote Connection Parameter Request Reply"
         case .remoteConnectionParameterRequestNegativeReply: return "LE Remote Connection Parameter Request Negative Reply Command"
         case .setDataLengthCommand: return "LE Set Data Length Command"

--- a/Sources/BluetoothHCI/LowEnergyEvent.swift
+++ b/Sources/BluetoothHCI/LowEnergyEvent.swift
@@ -69,6 +69,24 @@ public enum LowEnergyEvent: UInt8, HCIEvent {
 
     /// LE Channel Selection Algorithm Event
     case channelSelectionAlgorithm = 0x14
+
+    /// LE Periodic Advertising Sync Established Event (v2)
+    case periodicAdvertisingSyncEstablishedV2 = 0x24
+
+    /// LE Periodic Advertising Report Event (v2)
+    case periodicAdvertisingReportV2 = 0x25
+
+    /// LE Periodic Advertising Sync Transfer Received Event (v2)
+    case periodicAdvertisingSyncTransferReceivedV2 = 0x26
+
+    /// LE Periodic Advertising Subevent Data Request Event
+    case periodicAdvertisingSubeventDataRequest = 0x27
+
+    /// LE Periodic Advertising Response Report Event
+    case periodicAdvertisingResponseReport = 0x28
+
+    /// LE Enhanced Connection Complete Event (v2)
+    case enhancedConnectionCompleteV2 = 0x29
 }
 
 // MARK: - Name
@@ -98,6 +116,12 @@ public extension LowEnergyEvent {
         case .advertisingSetTerminated: return "LE Advertising Set Terminated Event"
         case .scanRequestReceived: return "LE Scan Request Received Event"
         case .channelSelectionAlgorithm: return "LE Channel Selection Algorithm Event"
+        case .periodicAdvertisingSyncEstablishedV2: return "LE Periodic Advertising Sync Established Event V2"
+        case .periodicAdvertisingReportV2: return "LE Periodic Advertising Report Event V2"
+        case .periodicAdvertisingSyncTransferReceivedV2: return "LE Periodic Advertising Sync Transfer Received Event V2"
+        case .periodicAdvertisingSubeventDataRequest: return "LE Periodic Advertising Subevent Data Request Event"
+        case .periodicAdvertisingResponseReport: return "LE Periodic Advertising Response Report Event"
+        case .enhancedConnectionCompleteV2: return "LE Enhanced Connection Complete Event V2"
         }
     }
 }

--- a/Tests/BluetoothTests/HCITests.swift
+++ b/Tests/BluetoothTests/HCITests.swift
@@ -3331,6 +3331,317 @@ import Foundation
         let rawValues = LowEnergyFeature.allCases.map { $0.rawValue }
         #expect(Set(rawValues).count == rawValues.count)
     }
+
+    @Test func periodicAdvertisingParametersV2() {
+
+        let parameters = HCILESetPeriodicAdvertisingParametersV2(
+            advertisingHandle: 0x01,
+            periodicAdvertisingInterval: .init(rawValue: 0x0080...0x0100),
+            advertisingEventProperties: .includeTxPower,
+            numberOfSubevents: 0x03,
+            subeventInterval: 0x08,
+            responseSlotDelay: 0x02,
+            responseSlotSpacing: 0x04,
+            numberOfResponseSlots: 0x05)
+
+        #expect(HCILESetPeriodicAdvertisingParametersV2.command.rawValue == 0x0086)
+        #expect(
+            Data(parameters)
+                == Data([
+                    0x01,  // Advertising_Handle
+                    0x80, 0x00,  // Periodic_Advertising_Interval_Min
+                    0x00, 0x01,  // Periodic_Advertising_Interval_Max
+                    0x20, 0x00,  // Periodic_Advertising_Properties
+                    0x03,  // Num_Subevents
+                    0x08,  // Subevent_Interval
+                    0x02,  // Response_Slot_Delay
+                    0x04,  // Response_Slot_Spacing
+                    0x05  // Num_Response_Slots
+                ]))
+    }
+
+    @Test func periodicAdvertisingSubeventData() {
+
+        let parameters = HCILESetPeriodicAdvertisingSubeventData<[UInt8]>(
+            advertisingHandle: 0x01,
+            subevents: [
+                .init(subevent: 0x00, responseSlotStart: 0x00, responseSlotCount: 0x02, data: [0xAA, 0xBB]),
+                .init(subevent: 0x01, responseSlotStart: 0x02, responseSlotCount: 0x01, data: [])
+            ])
+
+        #expect(HCILESetPeriodicAdvertisingSubeventData<[UInt8]>.command.rawValue == 0x0082)
+        #expect(
+            Data(parameters)
+                == Data([
+                    0x01,  // Advertising_Handle
+                    0x02,  // Num_Subevents
+                    0x00, 0x00, 0x02, 0x02, 0xAA, 0xBB,  // subevent 0
+                    0x01, 0x02, 0x01, 0x00  // subevent 1 (no data)
+                ]))
+    }
+
+    @Test func periodicAdvertisingResponseData() {
+
+        let parameters = HCILESetPeriodicAdvertisingResponseData<[UInt8]>(
+            syncHandle: 0x000A,
+            requestEvent: 0x0102,
+            requestSubevent: 0x03,
+            responseSubevent: 0x03,
+            responseSlot: 0x05,
+            responseData: [0xDE, 0xAD])
+
+        #expect(HCILESetPeriodicAdvertisingResponseData<[UInt8]>.command.rawValue == 0x0083)
+        #expect(
+            Data(parameters)
+                == Data([
+                    0x0A, 0x00,  // Sync_Handle
+                    0x02, 0x01,  // Request_Event
+                    0x03,  // Request_Subevent
+                    0x03,  // Response_Subevent
+                    0x05,  // Response_Slot
+                    0x02,  // Response_Data_Length
+                    0xDE, 0xAD  // Response_Data
+                ]))
+    }
+
+    @Test func periodicSyncSubevent() async throws {
+
+        let parameters = HCILESetPeriodicSyncSubevent(
+            syncHandle: 0x0002,
+            periodicAdvertisingProperties: [],
+            subevents: [0x01, 0x05])
+
+        #expect(HCILESetPeriodicSyncSubevent.command.rawValue == 0x0084)
+        #expect(
+            Data(parameters)
+                == Data([
+                    0x02, 0x00,  // Sync_Handle
+                    0x00, 0x00,  // Periodic_Advertising_Properties
+                    0x02,  // Num_Subevents
+                    0x01, 0x05  // Subevents
+                ]))
+
+        // mock host controller round trip
+        let hostController = TestHostController()
+
+        hostController.queue.append(
+            .command(
+                HCILowEnergyCommand.setPeriodicSyncSubevent.opcode,
+                [0x84, 0x20, 0x07, 0x02, 0x00, 0x00, 0x00, 0x02, 0x01, 0x05]))
+
+        // command complete: status + Sync_Handle
+        hostController.queue.append(.event([0x0E, 0x06, 0x01, 0x84, 0x20, 0x00, 0x02, 0x00]))
+
+        let syncHandle = try await hostController.lowEnergySetPeriodicSyncSubevent(
+            syncHandle: 0x0002,
+            periodicAdvertisingProperties: [],
+            subevents: [0x01, 0x05])
+
+        #expect(syncHandle == 0x0002)
+    }
+
+    @Test func periodicAdvertisingSubeventDataRequest() {
+
+        let data = Data([0x01, 0x02, 0x03])
+
+        guard let event = HCILEPeriodicAdvertisingSubeventDataRequest(data: data)
+        else {
+            Issue.record("Could not decode event")
+            return
+        }
+
+        #expect(HCILEPeriodicAdvertisingSubeventDataRequest.event.rawValue == 0x27)
+        #expect(event.advertisingHandle == 0x01)
+        #expect(event.subeventStart == 0x02)
+        #expect(event.subeventDataCount == 0x03)
+
+        #expect(HCILEPeriodicAdvertisingSubeventDataRequest(data: Data([0x01])) == nil)
+    }
+
+    @Test func periodicAdvertisingResponseReport() {
+
+        let data = Data([
+            0x01,  // Advertising_Handle
+            0x02,  // Subevent
+            0x00,  // Tx_Status (transmitted)
+            0x02,  // Num_Responses
+            // response 0
+            0x14,  // Tx_Power (20)
+            0xC4,  // RSSI (-60)
+            0x00,  // CTE_Type
+            0x03,  // Response_Slot
+            0x00,  // Data_Status (complete)
+            0x02,  // Data_Length
+            0xAA, 0xBB,  // Data
+            // response 1 (failed, no data)
+            0x7F,  // Tx_Power (not available)
+            0x7F,  // RSSI (not available)
+            0x00,  // CTE_Type
+            0x04,  // Response_Slot
+            0xFF,  // Data_Status (failed)
+            0x00  // Data_Length
+        ])
+
+        guard let event = HCILEPeriodicAdvertisingResponseReport<[UInt8]>(data: data)
+        else {
+            Issue.record("Could not decode event")
+            return
+        }
+
+        #expect(HCILEPeriodicAdvertisingResponseReport<[UInt8]>.event.rawValue == 0x28)
+        #expect(event.advertisingHandle == 0x01)
+        #expect(event.subevent == 0x02)
+        #expect(event.txStatus == .transmitted)
+        #expect(event.responses.count == 2)
+        #expect(event.responses[0].txPower?.rawValue == 20)
+        #expect(event.responses[0].rssi?.rawValue == -60)
+        #expect(event.responses[0].responseSlot == 0x03)
+        #expect(event.responses[0].dataStatus == .complete)
+        #expect(event.responses[0].data == [0xAA, 0xBB])
+        #expect(event.responses[1].txPower == nil)
+        #expect(event.responses[1].rssi == nil)
+        #expect(event.responses[1].dataStatus == .failed)
+        #expect(event.responses[1].data.isEmpty)
+
+        // truncated
+        #expect(HCILEPeriodicAdvertisingResponseReport<[UInt8]>(data: data.prefix(8)) == nil)
+    }
+
+    @Test func periodicAdvertisingSyncEstablishedV2() {
+
+        let data = Data([
+            0x00,  // Status
+            0x02, 0x00,  // Sync_Handle
+            0x05,  // Advertising_SID
+            0x00,  // Advertiser_Address_Type
+            0xaf, 0xd2, 0x06, 0x2d, 0x70, 0xb0,  // Advertiser_Address
+            0x01,  // Advertiser_PHY
+            0x80, 0x00,  // Periodic_Advertising_Interval
+            0x00,  // Advertiser_Clock_Accuracy
+            0x03,  // Num_Subevents
+            0x08,  // Subevent_Interval
+            0x02,  // Response_Slot_Delay
+            0x04  // Response_Slot_Spacing
+        ])
+
+        guard let event = HCILEPeriodicAdvertisingSyncEstablishedV2(data: data)
+        else {
+            Issue.record("Could not decode event")
+            return
+        }
+
+        #expect(HCILEPeriodicAdvertisingSyncEstablishedV2.event.rawValue == 0x24)
+        #expect(event.status == .success)
+        #expect(event.syncHandle == 0x0002)
+        #expect(event.advertisingSID == 0x05)
+        #expect(event.advertiserAddress == BluetoothAddress(rawValue: "B0:70:2D:06:D2:AF")!)
+        #expect(event.advertiserPHY == .le1m)
+        #expect(event.periodicAdvertisingInterval.rawValue == 0x0080)
+        #expect(event.numberOfSubevents == 0x03)
+        #expect(event.subeventInterval == 0x08)
+        #expect(event.responseSlotDelay == 0x02)
+        #expect(event.responseSlotSpacing == 0x04)
+    }
+
+    @Test func periodicAdvertisingReportV2() {
+
+        let data = Data([
+            0x02, 0x00,  // Sync_Handle
+            0x14,  // Tx_Power
+            0xC4,  // RSSI (-60)
+            0x00,  // CTE_Type
+            0x34, 0x12,  // Periodic_Event_Counter
+            0x01,  // Subevent
+            0x00,  // Data_Status (complete)
+            0x03,  // Data_Length
+            0xAA, 0xBB, 0xCC  // Data
+        ])
+
+        guard let event = HCILEPeriodicAdvertisingReportV2<[UInt8]>(data: data)
+        else {
+            Issue.record("Could not decode event")
+            return
+        }
+
+        #expect(HCILEPeriodicAdvertisingReportV2<[UInt8]>.event.rawValue == 0x25)
+        #expect(event.syncHandle == 0x0002)
+        #expect(event.txPower.rawValue == 20)
+        #expect(event.rssi.rawValue == -60)
+        #expect(event.periodicEventCounter == 0x1234)
+        #expect(event.subevent == 0x01)
+        #expect(event.dataStatus == .complete)
+        #expect(event.data == [0xAA, 0xBB, 0xCC])
+
+        // truncated data
+        #expect(HCILEPeriodicAdvertisingReportV2<[UInt8]>(data: data.prefix(11)) == nil)
+    }
+
+    @Test func periodicAdvertisingSyncTransferReceivedV2() {
+
+        let data = Data([
+            0x00,  // Status
+            0x03, 0x00,  // Connection_Handle
+            0x22, 0x11,  // Service_Data
+            0x02, 0x00,  // Sync_Handle
+            0x05,  // Advertising_SID
+            0x00,  // Advertiser_Address_Type
+            0xaf, 0xd2, 0x06, 0x2d, 0x70, 0xb0,  // Advertiser_Address
+            0x01,  // Advertiser_PHY
+            0x80, 0x00,  // Periodic_Advertising_Interval
+            0x00,  // Advertiser_Clock_Accuracy
+            0x03,  // Num_Subevents
+            0x08,  // Subevent_Interval
+            0x02,  // Response_Slot_Delay
+            0x04  // Response_Slot_Spacing
+        ])
+
+        guard let event = HCILEPeriodicAdvertisingSyncTransferReceivedV2(data: data)
+        else {
+            Issue.record("Could not decode event")
+            return
+        }
+
+        #expect(HCILEPeriodicAdvertisingSyncTransferReceivedV2.event.rawValue == 0x26)
+        #expect(event.status == .success)
+        #expect(event.connectionHandle == 0x0003)
+        #expect(event.serviceData == 0x1122)
+        #expect(event.syncHandle == 0x0002)
+        #expect(event.advertiserAddress == BluetoothAddress(rawValue: "B0:70:2D:06:D2:AF")!)
+        #expect(event.numberOfSubevents == 0x03)
+        #expect(event.responseSlotSpacing == 0x04)
+    }
+
+    @Test func enhancedConnectionCompleteV2() {
+
+        let data = Data([
+            0x00,  // Status
+            0x03, 0x00,  // Connection_Handle
+            0x00,  // Role (central)
+            0x00,  // Peer_Address_Type
+            0xaf, 0xd2, 0x06, 0x2d, 0x70, 0xb0,  // Peer_Address
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // Local_Resolvable_Private_Address
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // Peer_Resolvable_Private_Address
+            0x28, 0x00,  // Connection_Interval
+            0x00, 0x00,  // Peripheral_Latency
+            0x2A, 0x00,  // Supervision_Timeout
+            0x00,  // Central_Clock_Accuracy
+            0x01,  // Advertising_Handle
+            0x02, 0x00  // Sync_Handle
+        ])
+
+        guard let event = HCILEEnhancedConnectionCompleteV2(data: data)
+        else {
+            Issue.record("Could not decode event")
+            return
+        }
+
+        #expect(HCILEEnhancedConnectionCompleteV2.event.rawValue == 0x29)
+        #expect(event.status == .success)
+        #expect(event.connectionHandle == 0x0003)
+        #expect(event.peerAddress == BluetoothAddress(rawValue: "B0:70:2D:06:D2:AF")!)
+        #expect(event.advertisingHandle == 0x01)
+        #expect(event.syncHandle == 0x0002)
+    }
 }
 
 @_silgen_name("swift_bluetooth_parse_event")


### PR DESCRIPTION
Phase 4 (final) of Bluetooth Core 5.4 support: Periodic Advertising with Responses. **Stacked on #211** (`feature/hci-cssa`) since both extend the LE command enum — merge #211 first, then retarget or merge this.

## Commands

| Command | Opcode | Return |
|---|---|---|
| `HCILESetPeriodicAdvertisingParametersV2` | `0x0086` | Advertising_Handle |
| `HCILESetPeriodicAdvertisingSubeventData<SubeventData>` | `0x0082` | Advertising_Handle |
| `HCILESetPeriodicAdvertisingResponseData<ResponseData>` | `0x0083` | Sync_Handle |
| `HCILESetPeriodicSyncSubevent` | `0x0084` | Sync_Handle |

Each has a `BluetoothHostControllerInterface` convenience method. The parameters-v2 command reuses the v1 nested types and adds the five PAwR subevent parameters. Subevent/response data payloads are generic over `DataContainer`.

## Events

- **New:** LE Periodic Advertising Subevent Data Request (`0x27`) and LE Periodic Advertising Response Report (`0x28`, variable-length array of per-slot responses).
- **V2 revisions** (new subevent codes, separate structs): Periodic Advertising Sync Established v2 (`0x24`), Periodic Advertising Report v2 (`0x25`, adds periodic event counter + subevent), Periodic Advertising Sync Transfer Received v2 (`0x26`), Enhanced Connection Complete v2 (`0x29`, adds advertising/sync handles for connections created from PAwR).
- Response report `Tx_Power`/`RSSI` are optionals: the spec's `0x7F` "not available" value is outside both types' valid ranges and decodes as `nil` (same pattern as `HCILEAdvertisingReport.Report.rssi`).

All opcodes, subevent codes, and wire layouts verified against Zephyr's `hci_types.h`.

## Tests

Byte-exact encode vectors for all four commands, decode tests for all six events (including truncation rejection and the 0x7F case), and a mock host-controller round trip of LE Set Periodic Sync Subevent. Full suite: 295 tests pass; lint clean; release build verified.