### PR TITLE
Implement mandatory GATT ICS gaps: multi-value ATT PDUs and GATT profile characteristics

### DIFF
--- a/Sources/BluetoothGATT/ATTHandleValueMultipleNotification.swift
+++ b/Sources/BluetoothGATT/ATTHandleValueMultipleNotification.swift
@@ -1,0 +1,100 @@
+//
+//  ATTHandleValueMultipleNotification.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// Multiple Handle Value Notification
+///
+/// A server can send a notification of the values of multiple attributes at any time.
+@frozen
+public struct ATTHandleValueMultipleNotification<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+
+    public static var attributeOpcode: ATTOpcode { .handleValueMultipleNotification }
+
+    /// The attribute handles and values being notified.
+    public let notifications: [Notification]
+
+    public init?(notifications: [Notification]) {
+        guard notifications.isEmpty == false
+        else { return nil }
+        self.notifications = notifications
+    }
+}
+
+public extension ATTHandleValueMultipleNotification {
+
+    /// An attribute handle and value pair.
+    struct Notification: Equatable, Hashable, Sendable {
+
+        /// The handle of the attribute.
+        public var handle: UInt16
+
+        /// The value of the attribute.
+        public var value: Value
+
+        public init(handle: UInt16, value: Value) {
+            self.handle = handle
+            self.value = value
+        }
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTHandleValueMultipleNotification: DataConvertible {
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count >= 5,
+            Self.validateOpcode(data)
+        else { return nil }
+
+        var notifications = [Notification]()
+
+        var offset = 1
+        while offset < data.count {
+
+            // Attribute Handle + Value Length
+            guard data.count >= offset + 4
+            else { return nil }
+
+            let handle = UInt16(littleEndian: UInt16(bytes: (data[offset], data[offset + 1])))
+            let length = Int(UInt16(littleEndian: UInt16(bytes: (data[offset + 2], data[offset + 3]))))
+            offset += 4
+
+            // Attribute Value
+            guard data.count >= offset + length
+            else { return nil }
+
+            let value: Value
+            if length > 0 {
+                value = Value(data.subdata(in: offset..<offset + length))
+            } else {
+                value = Value()
+            }
+            offset += length
+
+            notifications.append(Notification(handle: handle, value: value))
+        }
+
+        self.init(notifications: notifications)
+    }
+
+    public func append<Data>(to data: inout Data) where Data: DataContainer {
+        data += Self.attributeOpcode.rawValue
+        for notification in notifications {
+            data += notification.handle.littleEndian
+            data += UInt16(notification.value.count).littleEndian
+            data += notification.value
+        }
+    }
+
+    public var dataLength: Int {
+        1 + notifications.reduce(0) { $0 + 4 + $1.value.count }
+    }
+}

--- a/Sources/BluetoothGATT/ATTOpcode.swift
+++ b/Sources/BluetoothGATT/ATTOpcode.swift
@@ -65,6 +65,13 @@ public enum ATTOpcode: UInt8, Sendable, CaseIterable {
     case handleValueNotification = 0x1B
     case handleValueIndication = 0x1D
     case handleValueConfirmation = 0x1E
+
+    // Read Multiple Variable Length
+    case readMultipleVariableLengthRequest = 0x20
+    case readMultipleVariableLengthResponse = 0x21
+
+    // Handle Value Multiple
+    case handleValueMultipleNotification = 0x23
 }
 
 // MARK: - CustomStringConvertible
@@ -126,6 +133,9 @@ public extension ATTOpcode {
         case .handleValueNotification: return .notification
         case .handleValueIndication: return .indication
         case .handleValueConfirmation: return .confirmation
+        case .readMultipleVariableLengthRequest: return .request
+        case .readMultipleVariableLengthResponse: return .response
+        case .handleValueMultipleNotification: return .notification
         }
     }
 
@@ -154,7 +164,8 @@ private extension ATTOpcode {
         (readByGroupTypeRequest, readByGroupTypeResponse),
         (writeRequest, writeResponse),
         (preparedWriteRequest, preparedWriteResponse),
-        (executeWriteRequest, executeWriteResponse)
+        (executeWriteRequest, executeWriteResponse),
+        (readMultipleVariableLengthRequest, readMultipleVariableLengthResponse)
     ]
     // swiftlint:enable comma
 

--- a/Sources/BluetoothGATT/ATTReadMultipleVariableLengthRequest.swift
+++ b/Sources/BluetoothGATT/ATTReadMultipleVariableLengthRequest.swift
@@ -1,0 +1,64 @@
+//
+//  ATTReadMultipleVariableLengthRequest.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// Read Multiple Variable Length Request
+///
+/// The *Read Multiple Variable Length Request* is used to request the server to read two or more values
+/// of a set of attributes that have a variable or unknown value length and return their values in a
+/// *Read Multiple Variable Length Response*.
+@frozen
+public struct ATTReadMultipleVariableLengthRequest: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+
+    public static var attributeOpcode: ATTOpcode { .readMultipleVariableLengthRequest }
+
+    /// The handles of the attributes to read.
+    public let handles: [UInt16]
+
+    public init?(handles: [UInt16]) {
+        guard handles.count >= 2
+        else { return nil }
+        self.handles = handles
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadMultipleVariableLengthRequest: DataConvertible {
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count >= 5,
+            Self.validateOpcode(data)
+        else { return nil }
+
+        let handleCount = (data.count - 1) / 2
+
+        guard (data.count - 1) % 2 == 0
+        else { return nil }
+
+        let handles = (0..<handleCount).map { index in
+            let handleIndex = 1 + (index * 2)
+            return UInt16(littleEndian: UInt16(bytes: (data[handleIndex], data[handleIndex + 1])))
+        }
+
+        self.init(handles: handles)
+    }
+
+    public func append<Data>(to data: inout Data) where Data: DataContainer {
+        data += Self.attributeOpcode.rawValue
+        for handle in handles {
+            data += handle.littleEndian
+        }
+    }
+
+    public var dataLength: Int {
+        1 + (2 * handles.count)
+    }
+}

--- a/Sources/BluetoothGATT/ATTReadMultipleVariableLengthResponse.swift
+++ b/Sources/BluetoothGATT/ATTReadMultipleVariableLengthResponse.swift
@@ -1,0 +1,78 @@
+//
+//  ATTReadMultipleVariableLengthResponse.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// Read Multiple Variable Length Response
+///
+/// The *Read Multiple Variable Length Response* is sent in reply to a received
+/// *Read Multiple Variable Length Request* and contains the values of the attributes that have been read.
+///
+/// Each value is preceded by its length, in the same order as the requested handles.
+@frozen
+public struct ATTReadMultipleVariableLengthResponse<Value: DataContainer>: ATTProtocolDataUnit, Equatable, Hashable, Sendable {
+
+    public static var attributeOpcode: ATTOpcode { .readMultipleVariableLengthResponse }
+
+    /// The values of the attributes that have been read, in the same order as the requested handles.
+    public var values: [Value]
+
+    public init(values: [Value]) {
+        self.values = values
+    }
+}
+
+// MARK: - DataConvertible
+
+extension ATTReadMultipleVariableLengthResponse: DataConvertible {
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count >= 1,
+            Self.validateOpcode(data)
+        else { return nil }
+
+        var values = [Value]()
+
+        var offset = 1
+        while offset < data.count {
+
+            // Value_Length
+            guard data.count >= offset + 2
+            else { return nil }
+
+            let length = Int(UInt16(littleEndian: UInt16(bytes: (data[offset], data[offset + 1]))))
+            offset += 2
+
+            // Value
+            guard data.count >= offset + length
+            else { return nil }
+
+            if length > 0 {
+                values.append(Value(data.subdata(in: offset..<offset + length)))
+            } else {
+                values.append(Value())
+            }
+            offset += length
+        }
+
+        self.init(values: values)
+    }
+
+    public func append<Data>(to data: inout Data) where Data: DataContainer {
+        data += Self.attributeOpcode.rawValue
+        for value in values {
+            data += UInt16(value.count).littleEndian
+            data += value
+        }
+    }
+
+    public var dataLength: Int {
+        1 + values.reduce(0) { $0 + 2 + $1.count }
+    }
+}

--- a/Sources/BluetoothGATT/GATTClientSupportedFeatures.swift
+++ b/Sources/BluetoothGATT/GATTClientSupportedFeatures.swift
@@ -1,0 +1,75 @@
+//
+//  GATTClientSupportedFeatures.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// Client Supported Features
+///
+/// The Client Supported Features characteristic is used by the client to inform the server
+/// which features are supported by the client. The value is a variable-length bit field;
+/// each bit, when set, indicates support for the associated feature.
+///
+/// - SeeAlso: [Bluetooth Core Specification](https://www.bluetooth.com/specifications/specs/) Vol 3 Part G 7.2
+@frozen
+public struct GATTClientSupportedFeatures: GATTCharacteristic, Equatable, Hashable, Sendable {
+
+    public static var uuid: BluetoothUUID { BluetoothUUID.Characteristic.clientSupportedFeatures }
+
+    /// The features supported by the client.
+    public var features: BitMaskOptionSet<Feature>
+
+    public init(features: BitMaskOptionSet<Feature> = []) {
+
+        self.features = features
+    }
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard let bitmask = Feature.RawValue(bitmaskArray: data)
+        else { return nil }
+
+        self.features = BitMaskOptionSet<Feature>(rawValue: bitmask)
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        data.append(contentsOf: features.rawValue.bitmaskArray)
+    }
+
+    public var dataLength: Int {
+
+        return features.rawValue.bitmaskArray.count
+    }
+
+    /// GATT client features.
+    public enum Feature: UInt64, BitMaskOption {
+
+        /// Robust Caching
+        ///
+        /// The client supports robust caching.
+        case robustCaching = 0b001
+
+        /// Enhanced ATT bearer
+        ///
+        /// The client supports the Enhanced ATT bearer (EATT).
+        case enhancedATT = 0b010
+
+        /// Multiple Handle Value Notifications
+        ///
+        /// The client supports receiving `ATT_MULTIPLE_HANDLE_VALUE_NTF` PDUs.
+        case multipleHandleValueNotifications = 0b100
+
+        public static var allCases: [Feature] {
+            [
+                .robustCaching,
+                .enhancedATT,
+                .multipleHandleValueNotifications
+            ]
+        }
+    }
+}

--- a/Sources/BluetoothGATT/GATTDatabaseHash.swift
+++ b/Sources/BluetoothGATT/GATTDatabaseHash.swift
@@ -1,0 +1,56 @@
+//
+//  GATTDatabaseHash.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// Database Hash
+///
+/// The Database Hash characteristic contains the result of a hash function applied to the
+/// service definitions in the GATT database. The value is a 128-bit AES-CMAC hash which
+/// clients supporting robust caching use to detect changes to the attribute database.
+///
+/// - Note: This type only carries the hash value; computing the AES-CMAC over the
+/// database contents is out of scope for this library.
+///
+/// - SeeAlso: [Bluetooth Core Specification](https://www.bluetooth.com/specifications/specs/) Vol 3 Part G 7.3
+@frozen
+public struct GATTDatabaseHash: GATTCharacteristic, Equatable, Hashable, Sendable {
+
+    internal static let length = MemoryLayout<UInt128>.size
+
+    public static var uuid: BluetoothUUID { BluetoothUUID.Characteristic.databaseHash }
+
+    /// 128-bit AES-CMAC hash of the GATT database.
+    public var hash: UInt128
+
+    public init(hash: UInt128) {
+
+        self.hash = hash
+    }
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count == Self.length
+        else { return nil }
+
+        guard let hash = UInt128(data: data)
+        else { return nil }
+
+        self.init(hash: UInt128(littleEndian: hash))
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        data += hash.littleEndian
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
+    }
+}

--- a/Sources/BluetoothGATT/GATTServiceChanged.swift
+++ b/Sources/BluetoothGATT/GATTServiceChanged.swift
@@ -1,0 +1,66 @@
+//
+//  GATTServiceChanged.swift
+//  Bluetooth
+//
+//  Created by Alsey Coleman Miller on 7/9/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+import Bluetooth
+
+/// Service Changed
+///
+/// The Service Changed characteristic is a control-point attribute that shall be used to
+/// indicate to connected devices that services have changed (i.e., added, removed, or modified).
+///
+/// The value is two 16-bit attribute handles indicating the beginning and ending of the
+/// affected attribute handle range on the server.
+///
+/// - SeeAlso: [Bluetooth Core Specification](https://www.bluetooth.com/specifications/specs/) Vol 3 Part G 7.1
+@frozen
+public struct GATTServiceChanged: GATTCharacteristic, Equatable, Hashable, Sendable {
+
+    internal static let length = MemoryLayout<UInt16>.size * 2
+
+    public static var uuid: BluetoothUUID { BluetoothUUID.Characteristic.serviceChanged }
+
+    /// Start of affected attribute handle range.
+    public var start: UInt16
+
+    /// End of affected attribute handle range.
+    public var end: UInt16
+
+    public init(start: UInt16, end: UInt16) {
+
+        self.start = start
+        self.end = end
+    }
+
+    public init?<Data: DataContainer>(data: Data) {
+
+        guard data.count == Self.length
+        else { return nil }
+
+        self.init(
+            start: UInt16(littleEndian: UInt16(bytes: (data[0], data[1]))),
+            end: UInt16(littleEndian: UInt16(bytes: (data[2], data[3]))))
+    }
+
+    public func append<Data: DataContainer>(to data: inout Data) {
+
+        let startBytes = start.littleEndian.bytes
+        let endBytes = end.littleEndian.bytes
+
+        data += [
+            startBytes.0,
+            startBytes.1,
+            endBytes.0,
+            endBytes.1
+        ]
+    }
+
+    public var dataLength: Int {
+
+        return Self.length
+    }
+}

--- a/Tests/BluetoothTests/AttributeProtocolTests.swift
+++ b/Tests/BluetoothTests/AttributeProtocolTests.swift
@@ -1189,6 +1189,98 @@ import Foundation
             }
         }
     }
+
+    @Test func readMultipleVariableLengthRequest() {
+
+        #expect(ATTOpcode.readMultipleVariableLengthRequest.type == .request)
+        #expect(ATTOpcode.readMultipleVariableLengthRequest.response == .readMultipleVariableLengthResponse)
+        #expect(ATTOpcode.readMultipleVariableLengthResponse.request == .readMultipleVariableLengthRequest)
+
+        // requires at least 2 handles
+        #expect(ATTReadMultipleVariableLengthRequest(handles: []) == nil)
+        #expect(ATTReadMultipleVariableLengthRequest(handles: [0x0003]) == nil)
+
+        let data = Data([0x20, 0x03, 0x00, 0x05, 0x00])
+
+        guard let request = ATTReadMultipleVariableLengthRequest(data: data)
+        else {
+            Issue.record("Could not parse")
+            return
+        }
+
+        #expect(request.handles == [0x0003, 0x0005])
+        #expect(request.data == data)
+        #expect(request.dataLength == data.count)
+
+        // truncated / odd handle bytes
+        #expect(ATTReadMultipleVariableLengthRequest(data: Data([0x20, 0x03, 0x00])) == nil)
+        #expect(ATTReadMultipleVariableLengthRequest(data: Data([0x20, 0x03, 0x00, 0x05, 0x00, 0x07])) == nil)
+        // wrong opcode
+        #expect(ATTReadMultipleVariableLengthRequest(data: Data([0x0E, 0x03, 0x00, 0x05, 0x00])) == nil)
+    }
+
+    @Test func readMultipleVariableLengthResponse() {
+
+        #expect(ATTOpcode.readMultipleVariableLengthResponse.type == .response)
+
+        // (Length: 2, Value: 0xAA BB), (Length: 0), (Length: 1, Value: 0xCC)
+        let data = Data([0x21, 0x02, 0x00, 0xAA, 0xBB, 0x00, 0x00, 0x01, 0x00, 0xCC])
+
+        guard let response = ATTReadMultipleVariableLengthResponse<Data>(data: data)
+        else {
+            Issue.record("Could not parse")
+            return
+        }
+
+        #expect(response.values.count == 3)
+        #expect(response.values[0] == Data([0xAA, 0xBB]))
+        #expect(response.values[1].isEmpty)
+        #expect(response.values[2] == Data([0xCC]))
+        #expect(response.data == data)
+        #expect(response.dataLength == data.count)
+
+        // empty response (no values)
+        let empty = ATTReadMultipleVariableLengthResponse<Data>(values: [])
+        #expect(empty.data == Data([0x21]))
+
+        // truncated length prefix
+        #expect(ATTReadMultipleVariableLengthResponse<Data>(data: Data([0x21, 0x02])) == nil)
+        // truncated value
+        #expect(ATTReadMultipleVariableLengthResponse<Data>(data: Data([0x21, 0x02, 0x00, 0xAA])) == nil)
+    }
+
+    @Test func handleValueMultipleNotification() {
+
+        #expect(ATTOpcode.handleValueMultipleNotification.type == .notification)
+
+        // requires at least 1 notification
+        #expect(ATTHandleValueMultipleNotification<Data>(notifications: []) == nil)
+
+        // (Handle: 0x0021, Length: 2, Value: 0x01 0x02), (Handle: 0x0025, Length: 0)
+        let data = Data([0x23, 0x21, 0x00, 0x02, 0x00, 0x01, 0x02, 0x25, 0x00, 0x00, 0x00])
+
+        guard let notification = ATTHandleValueMultipleNotification<Data>(data: data)
+        else {
+            Issue.record("Could not parse")
+            return
+        }
+
+        #expect(notification.notifications.count == 2)
+        #expect(notification.notifications[0].handle == 0x0021)
+        #expect(notification.notifications[0].value == Data([0x01, 0x02]))
+        #expect(notification.notifications[1].handle == 0x0025)
+        #expect(notification.notifications[1].value.isEmpty)
+        #expect(notification.data == data)
+        #expect(notification.dataLength == data.count)
+
+        // round trip through non-Foundation container
+        #expect(ATTHandleValueMultipleNotification<[UInt8]>(data: [UInt8](data))?.data == data)
+
+        // truncated tuple header
+        #expect(ATTHandleValueMultipleNotification<Data>(data: Data([0x23, 0x21, 0x00, 0x02])) == nil)
+        // truncated value
+        #expect(ATTHandleValueMultipleNotification<Data>(data: Data([0x23, 0x21, 0x00, 0x02, 0x00, 0x01])) == nil)
+    }
 }
 
 internal extension ATTProtocolDataUnit {

--- a/Tests/BluetoothTests/GATTCharacteristicTests.swift
+++ b/Tests/BluetoothTests/GATTCharacteristicTests.swift
@@ -1655,6 +1655,76 @@ import Bluetooth
         #expect(GATTLESecurityLevels(data: Data([0x01, 0x04, 0x02])) == nil)
         #expect(GATTLESecurityLevels(requirements: []) == nil)
     }
+
+    @Test func serviceChanged() {
+
+        // affected handle range 0x0001 - 0xFFFF
+        let data = Data([0x01, 0x00, 0xFF, 0xFF])
+
+        guard let characteristic = GATTServiceChanged(data: data)
+        else {
+            Issue.record("Could not decode from bytes")
+            return
+        }
+
+        roundTrip(characteristic, encodes: data)
+        #expect(characteristic.start == 0x0001)
+        #expect(characteristic.end == 0xFFFF)
+        #expect(GATTServiceChanged.uuid == BluetoothUUID.Characteristic.serviceChanged)
+        #expect(GATTServiceChanged(data: data) == GATTServiceChanged(data: data))
+
+        // invalid length
+        #expect(GATTServiceChanged(data: Data([0x01, 0x00])) == nil)
+        #expect(GATTServiceChanged(data: Data([0x01, 0x00, 0xFF, 0xFF, 0x00])) == nil)
+    }
+
+    @Test func clientSupportedFeatures() {
+
+        // Robust Caching + Multiple Handle Value Notifications
+        let data = Data([0b101])
+
+        guard let characteristic = GATTClientSupportedFeatures(data: data)
+        else {
+            Issue.record("Could not decode from bytes")
+            return
+        }
+
+        roundTrip(characteristic, encodes: data)
+        #expect(characteristic.features.contains(.robustCaching))
+        #expect(characteristic.features.contains(.enhancedATT) == false)
+        #expect(characteristic.features.contains(.multipleHandleValueNotifications))
+        #expect(GATTClientSupportedFeatures.uuid == BluetoothUUID.Characteristic.clientSupportedFeatures)
+
+        // all features
+        let allFeatures = GATTClientSupportedFeatures(features: [.robustCaching, .enhancedATT, .multipleHandleValueNotifications])
+        roundTrip(allFeatures, encodes: Data([0b111]))
+
+        // invalid: empty
+        #expect(GATTClientSupportedFeatures(data: Data()) == nil)
+    }
+
+    @Test func databaseHash() {
+
+        let data = Data([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+        ])
+
+        guard let characteristic = GATTDatabaseHash(data: data)
+        else {
+            Issue.record("Could not decode from bytes")
+            return
+        }
+
+        roundTrip(characteristic, encodes: data)
+        #expect(GATTDatabaseHash.uuid == BluetoothUUID.Characteristic.databaseHash)
+        #expect(GATTDatabaseHash(data: data) == GATTDatabaseHash(data: data))
+
+        // invalid length
+        #expect(GATTDatabaseHash(data: Data([0x00])) == nil)
+        #expect(GATTDatabaseHash(data: data.prefix(15)) == nil)
+        #expect(GATTDatabaseHash(data: data + Data([0x00])) == nil)
+    }
 }
 
 internal extension GATTCharacteristic {


### PR DESCRIPTION
Implements the wire types that the Bluetooth SIG GATT ICS proforma (`GATT.ICS.p23`, rev 2026-05-05) marks as mandatory or conditional-mandatory for any modern (Core 5.2+) implementation — the GATT counterpart to #213.

## ATT PDUs (Core 5.2, Vol 3 Part F)

| PDU | Opcode | ICS items |
|---|---|---|
| `ATTReadMultipleVariableLengthRequest` | `0x20` | GATT 3/29, 4/30; ATT 9/14, 10/11 |
| `ATTReadMultipleVariableLengthResponse<Value>` | `0x21` | (response pair of the above) |
| `ATTHandleValueMultipleNotification<Value>` | `0x23` | GATT 3/30, 4/31; ATT 9/15, 10/12 |

- Per Table 3 conditional C.10, these become **mandatory** the moment Host Core v5.2+ and an Enhanced ATT bearer are both claimed.
- New `ATTOpcode` cases wired into the opcode-type classification and the request↔response pairing map. No exhaustive-switch fallout elsewhere.
- Wire formats verified against Zephyr's `att_internal.h`: the VL response is repeated `(Value_Length: 2, Value)` tuples; the multi-notification is repeated `(Handle: 2, Length: 2, Value)` tuples. Both decoders validate tuple-header and value truncation; zero-length values round-trip.
- The request requires ≥2 handles per §3.4.4.11 (failable init, same as the existing `ATTReadMultipleRequest`); handles are appended explicitly little-endian.

## GATT profile characteristics (Vol 3 Part G §7.1–7.3)

- **`GATTServiceChanged`** (`0x2A05`) — start/end affected handle range. This is the one item the ICS marks **unconditionally mandatory** for both GATT client and server roles (Table 3/4 item 23); until now the library had only the UUID in metadata.
- **`GATTClientSupportedFeatures`** (`0x2B29`) — variable-length feature bit field (Robust Caching, Enhanced ATT, Multiple Handle Value Notifications), using the same `bitmaskArray` variable-length encoding as `GATTAlertCategoryBitMask`.
- **`GATTDatabaseHash`** (`0x2B2A`) — 128-bit AES-CMAC value carrier (`UInt128`, little-endian). Computing the hash over the database is intentionally out of scope (no crypto dependency).

## Not in scope

Wiring the new PDUs into the `GATTClient`/`GATTServer` connection state machines (issuing/handling them during live connections) — that touches the ATT connection flow and is deferred to a follow-up.

## Tests

Byte-exact decode/encode vectors for all six types, truncation and wrong-opcode rejection, zero-length value handling, non-Foundation container round trips (via the existing `roundTrip` helper for characteristics), and opcode classification/pairing assertions. Full suite: **313 tests pass** (up from 307); lint clean.